### PR TITLE
Add support for multiple pokedex entries

### DIFF
--- a/app/Console/Commands/SyncPokedexFromGame.php
+++ b/app/Console/Commands/SyncPokedexFromGame.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Pokedex;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+
+class SyncPokedexFromGame extends Command
+{
+    public const NATIONAL_MAX = 905;
+
+    public const POKEDEX_DAT_URL = 'https://raw.githubusercontent.com/P3D-Legacy/P3D-Legacy/master/P3D/Content/Data/pokedex.dat';
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'sync:pokedexfromgame';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sync Pokédex definitions from the game data file';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $this->info('Syncing Pokédex definitions from game...');
+
+        $response = Http::get(self::POKEDEX_DAT_URL);
+
+        if ($response->failed()) {
+            $this->error('Failed to fetch pokedex.dat from the game repository.');
+
+            return self::FAILURE;
+        }
+
+        $lines = preg_split("/\r\n|\n|\r/", $response->body()) ?: [];
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+
+            if ($line === '') {
+                continue;
+            }
+
+            $parts = explode('|', $line);
+
+            if (count($parts) < 3) {
+                $this->warn("Skipping malformed line: {$line}");
+
+                continue;
+            }
+
+            $name = trim($parts[0]);
+            $slug = trim($parts[1]);
+            $pokemonIds = $this->expandPokemonIds(trim($parts[2]));
+
+            if ($slug === '') {
+                $this->warn("Skipping Pokédex without slug: {$name}");
+
+                continue;
+            }
+
+            Pokedex::query()->updateOrCreate(
+                ['slug' => $slug],
+                [
+                    'name' => $name,
+                    'pokemon_ids' => $pokemonIds,
+                ]
+            );
+
+            $this->info("Synced {$name} ({$slug}) with ".count($pokemonIds).' entries.');
+        }
+
+        $this->info('All done!');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function expandPokemonIds(string $idList): array
+    {
+        $pokemonIds = [];
+
+        foreach (explode(',', $idList) as $token) {
+            $token = trim($token);
+
+            if ($token === '') {
+                continue;
+            }
+
+            if (str_contains($token, '-')) {
+                [$start, $end] = explode('-', $token, 2);
+                $startCount = (int) $start;
+                $endCount = str_contains($end, 'MAX') ? self::NATIONAL_MAX : (int) $end;
+
+                if ($startCount > $endCount) {
+                    continue;
+                }
+
+                for ($i = $startCount; $i <= $endCount; $i++) {
+                    $pokemonIds[] = (string) $i;
+                }
+
+                continue;
+            }
+
+            $pokemonIds[] = $token;
+        }
+
+        return $pokemonIds;
+    }
+}

--- a/app/Models/GameSave.php
+++ b/app/Models/GameSave.php
@@ -145,7 +145,7 @@ class GameSave extends Model
 
             return array_map(function ($item) {
                 $item = explode('|', $item);
-                $id = str_replace('{', '', $item[0]);
+                $id = str_replace(['{', '}'], '', $item[0]);
                 $status = (int) $item[1];
 
                 return [
@@ -157,6 +157,39 @@ class GameSave extends Model
             }, $pokedex);
         } catch (Exception $e) {
             // If there is an error, return an empty array and log the error
+            Log::error($e->getMessage());
+
+            return [];
+        }
+    }
+
+    /**
+     * Return Pokédex entries for the given IDs in definition order.
+     * Missing save rows are returned as unseen placeholders.
+     *
+     * @param  list<string>  $ids
+     * @return list<array{id: string, name: string, seen: bool, caught: bool}>
+     */
+    public function getPokedexByIds(array $ids): array
+    {
+        try {
+            $entriesById = collect($this->getPokedex())->keyBy('id');
+
+            return array_map(function (string $id) use ($entriesById): array {
+                $entry = $entriesById->get($id);
+
+                if (is_array($entry)) {
+                    return $entry;
+                }
+
+                return [
+                    'id' => $id,
+                    'name' => $this->getPokemonName($id),
+                    'seen' => false,
+                    'caught' => false,
+                ];
+            }, array_values($ids));
+        } catch (Exception $e) {
             Log::error($e->getMessage());
 
             return [];
@@ -288,7 +321,7 @@ class GameSave extends Model
 
                 return [
                     'id' => $pokemonId,
-                    'name' => $this->getPokemonName($pokemonId),
+                    'name' => $this->getPokemonName((string) $pokemonId),
                     'nickname' => $nickname !== '' ? $nickname : null,
                     'level' => (int) ($raw['Level'] ?? 0),
                     'gender' => $this->getPartyGenderLabel($raw['Gender'] ?? null),
@@ -558,25 +591,24 @@ class GameSave extends Model
     }
 
     // Get the pokemon name from id
-    public function getPokemonName($id): string
+    public function getPokemonName(string $id): string
     {
         try {
-            // convert string id to int id
-            $id = (int) $id;
-            // get the language file path
             $filepath = lang_path().'/pokemon_'.app()->getLocale().'.json';
-            // if the file doesn't exist, use the default language
+
             if (! file_exists($filepath)) {
                 $filepath = lang_path().'/pokemon_en.json';
             }
-            // load pokemon names from json file in the lang folder
-            $pokemon_names = json_decode(file_get_contents($filepath), true);
-            // get the pokemon name by the id key in json file
-            $pokemon_names = collect($pokemon_names);
 
-            return isset($pokemon_names->get($id - 1)['name']) ? $pokemon_names->get($id - 1)['name'] : '???';
+            $pokemonNames = collect(json_decode(file_get_contents($filepath), true));
+            $match = $pokemonNames->firstWhere('id', $id);
+
+            if (! is_array($match)) {
+                return '???';
+            }
+
+            return $match['name'] ?? '???';
         } catch (Exception $e) {
-            // If there is an error, return an empty array and log the error
             Log::error($e->getMessage());
 
             return '???';

--- a/app/Models/Pokedex.php
+++ b/app/Models/Pokedex.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\PokedexFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Pokedex extends BaseModel
+{
+    /** @use HasFactory<PokedexFactory> */
+    use HasFactory;
+
+    protected $table = 'pokedex';
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'pokemon_ids',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'pokemon_ids' => 'array',
+        ];
+    }
+}

--- a/app/Support/GameSavePresenter.php
+++ b/app/Support/GameSavePresenter.php
@@ -2,6 +2,7 @@
 
 namespace App\Support;
 
+use App\Models\Pokedex;
 use App\Models\User;
 
 class GameSavePresenter
@@ -24,6 +25,24 @@ class GameSavePresenter
         }
 
         $trophies = $gamejolt->trophies ?? collect();
+        $pokedexes = Pokedex::query()
+            ->orderBy('id')
+            ->get()
+            ->map(function (Pokedex $pokedex) use ($gamesave): array {
+                $entries = $gamesave->getPokedexByIds($pokedex->pokemon_ids ?? []);
+                $caughtCount = count(array_filter($entries, fn (array $entry): bool => $entry['caught']));
+                $seenCount = count(array_filter($entries, fn (array $entry): bool => $entry['seen']));
+
+                return [
+                    'slug' => $pokedex->slug,
+                    'name' => $pokedex->name,
+                    'caught_count' => $caughtCount,
+                    'seen_count' => $seenCount,
+                    'entries' => $entries,
+                ];
+            })
+            ->values()
+            ->all();
 
         return [
             'available' => true,
@@ -32,7 +51,7 @@ class GameSavePresenter
             'seen_count' => $gamesave->getSeenPokemonCount(),
             'party' => array_values($gamesave->getParty()),
             'details' => $gamesave->getPlayerDataDetails(),
-            'pokedex' => array_values($gamesave->getPokedex()),
+            'pokedexes' => $pokedexes,
             'statistics' => array_values($gamesave->getStatistics()),
             'trophies' => [
                 'achieved' => $trophies->where('achieved', true)->count(),

--- a/database/factories/PokedexFactory.php
+++ b/database/factories/PokedexFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Pokedex;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Pokedex>
+ */
+class PokedexFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->words(2, true).' Pokédex';
+
+        return [
+            'name' => $name,
+            'slug' => str('pokedex_'.fake()->unique()->slug(2))->lower()->toString(),
+            'pokemon_ids' => ['1', '4', '7', '25'],
+        ];
+    }
+}

--- a/database/migrations/2026_07_22_203249_create_pokedexes_table.php
+++ b/database/migrations/2026_07_22_203249_create_pokedexes_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('pokedex', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->json('pokemon_ids');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('pokedex');
+    }
+};

--- a/lang/pokemon_en.json
+++ b/lang/pokemon_en.json
@@ -1,3622 +1,3926 @@
 [
     {
-        "id": 1,
+        "id": "1",
         "name": "Bulbasaur"
     },
     {
-        "id": 2,
+        "id": "2",
         "name": "Ivysaur"
     },
     {
-        "id": 3,
+        "id": "3",
         "name": "Venusaur"
     },
     {
-        "id": 4,
+        "id": "4",
         "name": "Charmander"
     },
     {
-        "id": 5,
+        "id": "5",
         "name": "Charmeleon"
     },
     {
-        "id": 6,
+        "id": "6",
         "name": "Charizard"
     },
     {
-        "id": 7,
+        "id": "7",
         "name": "Squirtle"
     },
     {
-        "id": 8,
+        "id": "8",
         "name": "Wartortle"
     },
     {
-        "id": 9,
+        "id": "9",
         "name": "Blastoise"
     },
     {
-        "id": 10,
+        "id": "10",
         "name": "Caterpie"
     },
     {
-        "id": 11,
+        "id": "11",
         "name": "Metapod"
     },
     {
-        "id": 12,
+        "id": "12",
         "name": "Butterfree"
     },
     {
-        "id": 13,
+        "id": "13",
         "name": "Weedle"
     },
     {
-        "id": 14,
+        "id": "14",
         "name": "Kakuna"
     },
     {
-        "id": 15,
+        "id": "15",
         "name": "Beedrill"
     },
     {
-        "id": 16,
+        "id": "16",
         "name": "Pidgey"
     },
     {
-        "id": 17,
+        "id": "17",
         "name": "Pidgeotto"
     },
     {
-        "id": 18,
+        "id": "18",
         "name": "Pidgeot"
     },
     {
-        "id": 19,
+        "id": "19",
         "name": "Rattata"
     },
     {
-        "id": 20,
+        "id": "19_alola",
+        "name": "Alolan Rattata"
+    },
+    {
+        "id": "20",
         "name": "Raticate"
     },
     {
-        "id": 21,
+        "id": "20_alola",
+        "name": "Alolan Raticate"
+    },
+    {
+        "id": "21",
         "name": "Spearow"
     },
     {
-        "id": 22,
+        "id": "22",
         "name": "Fearow"
     },
     {
-        "id": 23,
+        "id": "23",
         "name": "Ekans"
     },
     {
-        "id": 24,
+        "id": "24",
         "name": "Arbok"
     },
     {
-        "id": 25,
+        "id": "25",
         "name": "Pikachu"
     },
     {
-        "id": 26,
+        "id": "26",
         "name": "Raichu"
     },
     {
-        "id": 27,
+        "id": "26_alola",
+        "name": "Alolan Raichu"
+    },
+    {
+        "id": "27",
         "name": "Sandshrew"
     },
     {
-        "id": 28,
+        "id": "27_alola",
+        "name": "Alolan Sandshrew"
+    },
+    {
+        "id": "28",
         "name": "Sandslash"
     },
     {
-        "id": 29,
+        "id": "28_alola",
+        "name": "Alolan Sandslash"
+    },
+    {
+        "id": "29",
         "name": "Nidoran♂"
     },
     {
-        "id": 30,
+        "id": "30",
         "name": "Nidorina"
     },
     {
-        "id": 31,
+        "id": "31",
         "name": "Nidoqueen"
     },
     {
-        "id": 32,
+        "id": "32",
         "name": "Nidoran♀"
     },
     {
-        "id": 33,
+        "id": "33",
         "name": "Nidorino"
     },
     {
-        "id": 34,
+        "id": "34",
         "name": "Nidoking"
     },
     {
-        "id": 35,
+        "id": "35",
         "name": "Clefairy"
     },
     {
-        "id": 36,
+        "id": "36",
         "name": "Clefable"
     },
     {
-        "id": 37,
+        "id": "37",
         "name": "Vulpix"
     },
     {
-        "id": 38,
+        "id": "37_alola",
+        "name": "Alolan Vulpix"
+    },
+    {
+        "id": "38",
         "name": "Ninetales"
     },
     {
-        "id": 39,
+        "id": "38_alola",
+        "name": "Alolan Ninetales"
+    },
+    {
+        "id": "39",
         "name": "Jigglypuff"
     },
     {
-        "id": 40,
+        "id": "40",
         "name": "Wigglytuff"
     },
     {
-        "id": 41,
+        "id": "41",
         "name": "Zubat"
     },
     {
-        "id": 42,
+        "id": "42",
         "name": "Golbat"
     },
     {
-        "id": 43,
+        "id": "43",
         "name": "Oddish"
     },
     {
-        "id": 44,
+        "id": "44",
         "name": "Gloom"
     },
     {
-        "id": 45,
+        "id": "45",
         "name": "Vileplume"
     },
     {
-        "id": 46,
+        "id": "46",
         "name": "Paras"
     },
     {
-        "id": 47,
+        "id": "47",
         "name": "Parasect"
     },
     {
-        "id": 48,
+        "id": "48",
         "name": "Venonat"
     },
     {
-        "id": 49,
+        "id": "49",
         "name": "Venomoth"
     },
     {
-        "id": 50,
+        "id": "50",
         "name": "Diglett"
     },
     {
-        "id": 51,
+        "id": "50_alola",
+        "name": "Alolan Diglett"
+    },
+    {
+        "id": "51",
         "name": "Dugtrio"
     },
     {
-        "id": 52,
+        "id": "51_alola",
+        "name": "Alolan Dugtrio"
+    },
+    {
+        "id": "52",
         "name": "Meowth"
     },
     {
-        "id": 53,
+        "id": "52_alola",
+        "name": "Alolan Meowth"
+    },
+    {
+        "id": "52_galar",
+        "name": "Galarian Meowth"
+    },
+    {
+        "id": "53",
         "name": "Persian"
     },
     {
-        "id": 54,
+        "id": "53_alola",
+        "name": "Alolan Persian"
+    },
+    {
+        "id": "54",
         "name": "Psyduck"
     },
     {
-        "id": 55,
+        "id": "55",
         "name": "Golduck"
     },
     {
-        "id": 56,
+        "id": "56",
         "name": "Mankey"
     },
     {
-        "id": 57,
+        "id": "57",
         "name": "Primeape"
     },
     {
-        "id": 58,
+        "id": "58",
         "name": "Growlithe"
     },
     {
-        "id": 59,
+        "id": "58_hisui",
+        "name": "Hisuian Growlithe"
+    },
+    {
+        "id": "59",
         "name": "Arcanine"
     },
     {
-        "id": 60,
+        "id": "59_hisui",
+        "name": "Hisuian Arcanine"
+    },
+    {
+        "id": "60",
         "name": "Poliwag"
     },
     {
-        "id": 61,
+        "id": "61",
         "name": "Poliwhirl"
     },
     {
-        "id": 62,
+        "id": "62",
         "name": "Poliwrath"
     },
     {
-        "id": 63,
+        "id": "63",
         "name": "Abra"
     },
     {
-        "id": 64,
+        "id": "64",
         "name": "Kadabra"
     },
     {
-        "id": 65,
+        "id": "65",
         "name": "Alakazam"
     },
     {
-        "id": 66,
+        "id": "66",
         "name": "Machop"
     },
     {
-        "id": 67,
+        "id": "67",
         "name": "Machoke"
     },
     {
-        "id": 68,
+        "id": "68",
         "name": "Machamp"
     },
     {
-        "id": 69,
+        "id": "69",
         "name": "Bellsprout"
     },
     {
-        "id": 70,
+        "id": "70",
         "name": "Weepinbell"
     },
     {
-        "id": 71,
+        "id": "71",
         "name": "Victreebel"
     },
     {
-        "id": 72,
+        "id": "72",
         "name": "Tentacool"
     },
     {
-        "id": 73,
+        "id": "73",
         "name": "Tentacruel"
     },
     {
-        "id": 74,
+        "id": "74",
         "name": "Geodude"
     },
     {
-        "id": 75,
+        "id": "74_alola",
+        "name": "Alolan Geodude"
+    },
+    {
+        "id": "75",
         "name": "Graveler"
     },
     {
-        "id": 76,
+        "id": "75_alola",
+        "name": "Alolan Graveler"
+    },
+    {
+        "id": "76",
         "name": "Golem"
     },
     {
-        "id": 77,
+        "id": "76_alola",
+        "name": "Alolan Golem"
+    },
+    {
+        "id": "77",
         "name": "Ponyta"
     },
     {
-        "id": 78,
+        "id": "77_galar",
+        "name": "Galarian Ponyta"
+    },
+    {
+        "id": "78",
         "name": "Rapidash"
     },
     {
-        "id": 79,
+        "id": "78_galar",
+        "name": "Galarian Rapidash"
+    },
+    {
+        "id": "79",
         "name": "Slowpoke"
     },
     {
-        "id": 80,
+        "id": "79_galar",
+        "name": "Galarian Slowpoke"
+    },
+    {
+        "id": "80",
         "name": "Slowbro"
     },
     {
-        "id": 81,
+        "id": "80_galar",
+        "name": "Galarian Slowbro"
+    },
+    {
+        "id": "81",
         "name": "Magnemite"
     },
     {
-        "id": 82,
+        "id": "82",
         "name": "Magneton"
     },
     {
-        "id": 83,
+        "id": "83",
         "name": "Farfetch'd"
     },
     {
-        "id": 84,
+        "id": "83_galar",
+        "name": "Galarian Farfetch'd"
+    },
+    {
+        "id": "84",
         "name": "Doduo"
     },
     {
-        "id": 85,
+        "id": "85",
         "name": "Dodrio"
     },
     {
-        "id": 86,
+        "id": "86",
         "name": "Seel"
     },
     {
-        "id": 87,
+        "id": "87",
         "name": "Dewgong"
     },
     {
-        "id": 88,
+        "id": "88",
         "name": "Grimer"
     },
     {
-        "id": 89,
+        "id": "88_alola",
+        "name": "Alolan Grimer"
+    },
+    {
+        "id": "89",
         "name": "Muk"
     },
     {
-        "id": 90,
+        "id": "89_alola",
+        "name": "Alolan Muk"
+    },
+    {
+        "id": "90",
         "name": "Shellder"
     },
     {
-        "id": 91,
+        "id": "91",
         "name": "Cloyster"
     },
     {
-        "id": 92,
+        "id": "92",
         "name": "Gastly"
     },
     {
-        "id": 93,
+        "id": "93",
         "name": "Haunter"
     },
     {
-        "id": 94,
+        "id": "94",
         "name": "Gengar"
     },
     {
-        "id": 95,
+        "id": "95",
         "name": "Onix"
     },
     {
-        "id": 96,
+        "id": "96",
         "name": "Drowzee"
     },
     {
-        "id": 97,
+        "id": "97",
         "name": "Hypno"
     },
     {
-        "id": 98,
+        "id": "98",
         "name": "Krabby"
     },
     {
-        "id": 99,
+        "id": "99",
         "name": "Kingler"
     },
     {
-        "id": 100,
+        "id": "100",
         "name": "Voltorb"
     },
     {
-        "id": 101,
+        "id": "101",
         "name": "Electrode"
     },
     {
-        "id": 102,
+        "id": "102",
         "name": "Exeggcute"
     },
     {
-        "id": 103,
+        "id": "103",
         "name": "Exeggutor"
     },
     {
-        "id": 104,
+        "id": "103_alola",
+        "name": "Alolan Exeggutor"
+    },
+    {
+        "id": "104",
         "name": "Cubone"
     },
     {
-        "id": 105,
+        "id": "105",
         "name": "Marowak"
     },
     {
-        "id": 106,
+        "id": "105_alola",
+        "name": "Alolan Marowak"
+    },
+    {
+        "id": "106",
         "name": "Hitmonlee"
     },
     {
-        "id": 107,
+        "id": "107",
         "name": "Hitmonchan"
     },
     {
-        "id": 108,
+        "id": "108",
         "name": "Lickitung"
     },
     {
-        "id": 109,
+        "id": "109",
         "name": "Koffing"
     },
     {
-        "id": 110,
+        "id": "110",
         "name": "Weezing"
     },
     {
-        "id": 111,
+        "id": "110_galar",
+        "name": "Galarian Weezing"
+    },
+    {
+        "id": "111",
         "name": "Rhyhorn"
     },
     {
-        "id": 112,
+        "id": "112",
         "name": "Rhydon"
     },
     {
-        "id": 113,
+        "id": "113",
         "name": "Chansey"
     },
     {
-        "id": 114,
+        "id": "114",
         "name": "Tangela"
     },
     {
-        "id": 115,
+        "id": "115",
         "name": "Kangaskhan"
     },
     {
-        "id": 116,
+        "id": "116",
         "name": "Horsea"
     },
     {
-        "id": 117,
+        "id": "117",
         "name": "Seadra"
     },
     {
-        "id": 118,
+        "id": "118",
         "name": "Goldeen"
     },
     {
-        "id": 119,
+        "id": "119",
         "name": "Seaking"
     },
     {
-        "id": 120,
+        "id": "120",
         "name": "Staryu"
     },
     {
-        "id": 121,
+        "id": "121",
         "name": "Starmie"
     },
     {
-        "id": 122,
+        "id": "122",
         "name": "Mr. Mime"
     },
     {
-        "id": 123,
+        "id": "122_galar",
+        "name": "Galarian Mime"
+    },
+    {
+        "id": "123",
         "name": "Scyther"
     },
     {
-        "id": 124,
+        "id": "124",
         "name": "Jynx"
     },
     {
-        "id": 125,
+        "id": "125",
         "name": "Electabuzz"
     },
     {
-        "id": 126,
+        "id": "126",
         "name": "Magmar"
     },
     {
-        "id": 127,
+        "id": "127",
         "name": "Pinsir"
     },
     {
-        "id": 128,
+        "id": "128",
         "name": "Tauros"
     },
     {
-        "id": 129,
+        "id": "129",
         "name": "Magikarp"
     },
     {
-        "id": 130,
+        "id": "130",
         "name": "Gyarados"
     },
     {
-        "id": 131,
+        "id": "131",
         "name": "Lapras"
     },
     {
-        "id": 132,
+        "id": "132",
         "name": "Ditto"
     },
     {
-        "id": 133,
+        "id": "133",
         "name": "Eevee"
     },
     {
-        "id": 134,
+        "id": "134",
         "name": "Vaporeon"
     },
     {
-        "id": 135,
+        "id": "135",
         "name": "Jolteon"
     },
     {
-        "id": 136,
+        "id": "136",
         "name": "Flareon"
     },
     {
-        "id": 137,
+        "id": "137",
         "name": "Porygon"
     },
     {
-        "id": 138,
+        "id": "138",
         "name": "Omanyte"
     },
     {
-        "id": 139,
+        "id": "139",
         "name": "Omastar"
     },
     {
-        "id": 140,
+        "id": "140",
         "name": "Kabuto"
     },
     {
-        "id": 141,
+        "id": "141",
         "name": "Kabutops"
     },
     {
-        "id": 142,
+        "id": "142",
         "name": "Aerodactyl"
     },
     {
-        "id": 143,
+        "id": "143",
         "name": "Snorlax"
     },
     {
-        "id": 144,
+        "id": "144",
         "name": "Articuno"
     },
     {
-        "id": 145,
+        "id": "144_galar",
+        "name": "Galarian Articuno"
+    },
+    {
+        "id": "145",
         "name": "Zapdos"
     },
     {
-        "id": 146,
+        "id": "145_galar",
+        "name": "Galarian Zapdos"
+    },
+    {
+        "id": "146",
         "name": "Moltres"
     },
     {
-        "id": 147,
+        "id": "146_galar",
+        "name": "Galarian Moltres"
+    },
+    {
+        "id": "147",
         "name": "Dratini"
     },
     {
-        "id": 148,
+        "id": "148",
         "name": "Dragonair"
     },
     {
-        "id": 149,
+        "id": "149",
         "name": "Dragonite"
     },
     {
-        "id": 150,
+        "id": "150",
         "name": "Mewtwo"
     },
     {
-        "id": 151,
+        "id": "151",
         "name": "Mew"
     },
     {
-        "id": 152,
+        "id": "152",
         "name": "Chikorita"
     },
     {
-        "id": 153,
+        "id": "153",
         "name": "Bayleef"
     },
     {
-        "id": 154,
+        "id": "154",
         "name": "Meganium"
     },
     {
-        "id": 155,
+        "id": "155",
         "name": "Cyndaquil"
     },
     {
-        "id": 156,
+        "id": "156",
         "name": "Quilava"
     },
     {
-        "id": 157,
+        "id": "157",
         "name": "Typhlosion"
     },
     {
-        "id": 158,
+        "id": "158",
         "name": "Totodile"
     },
     {
-        "id": 159,
+        "id": "159",
         "name": "Croconaw"
     },
     {
-        "id": 160,
+        "id": "160",
         "name": "Feraligatr"
     },
     {
-        "id": 161,
+        "id": "161",
         "name": "Sentret"
     },
     {
-        "id": 162,
+        "id": "162",
         "name": "Furret"
     },
     {
-        "id": 163,
+        "id": "163",
         "name": "Hoothoot"
     },
     {
-        "id": 164,
+        "id": "164",
         "name": "Noctowl"
     },
     {
-        "id": 165,
+        "id": "165",
         "name": "Ledyba"
     },
     {
-        "id": 166,
+        "id": "166",
         "name": "Ledian"
     },
     {
-        "id": 167,
+        "id": "167",
         "name": "Spinarak"
     },
     {
-        "id": 168,
+        "id": "168",
         "name": "Ariados"
     },
     {
-        "id": 169,
+        "id": "169",
         "name": "Crobat"
     },
     {
-        "id": 170,
+        "id": "170",
         "name": "Chinchou"
     },
     {
-        "id": 171,
+        "id": "171",
         "name": "Lanturn"
     },
     {
-        "id": 172,
+        "id": "172",
         "name": "Pichu"
     },
     {
-        "id": 173,
+        "id": "173",
         "name": "Cleffa"
     },
     {
-        "id": 174,
+        "id": "174",
         "name": "Igglybuff"
     },
     {
-        "id": 175,
+        "id": "175",
         "name": "Togepi"
     },
     {
-        "id": 176,
+        "id": "176",
         "name": "Togetic"
     },
     {
-        "id": 177,
+        "id": "177",
         "name": "Natu"
     },
     {
-        "id": 178,
+        "id": "178",
         "name": "Xatu"
     },
     {
-        "id": 179,
+        "id": "179",
         "name": "Mareep"
     },
     {
-        "id": 180,
+        "id": "180",
         "name": "Flaaffy"
     },
     {
-        "id": 181,
+        "id": "181",
         "name": "Ampharos"
     },
     {
-        "id": 182,
+        "id": "182",
         "name": "Bellossom"
     },
     {
-        "id": 183,
+        "id": "183",
         "name": "Marill"
     },
     {
-        "id": 184,
+        "id": "184",
         "name": "Azumarill"
     },
     {
-        "id": 185,
+        "id": "185",
         "name": "Sudowoodo"
     },
     {
-        "id": 186,
+        "id": "186",
         "name": "Politoed"
     },
     {
-        "id": 187,
+        "id": "187",
         "name": "Hoppip"
     },
     {
-        "id": 188,
+        "id": "188",
         "name": "Skiploom"
     },
     {
-        "id": 189,
+        "id": "189",
         "name": "Jumpluff"
     },
     {
-        "id": 190,
+        "id": "190",
         "name": "Aipom"
     },
     {
-        "id": 191,
+        "id": "191",
         "name": "Sunkern"
     },
     {
-        "id": 192,
+        "id": "192",
         "name": "Sunflora"
     },
     {
-        "id": 193,
+        "id": "193",
         "name": "Yanma"
     },
     {
-        "id": 194,
+        "id": "194",
         "name": "Wooper"
     },
     {
-        "id": 195,
+        "id": "195",
         "name": "Quagsire"
     },
     {
-        "id": 196,
+        "id": "196",
         "name": "Espeon"
     },
     {
-        "id": 197,
+        "id": "197",
         "name": "Umbreon"
     },
     {
-        "id": 198,
+        "id": "198",
         "name": "Murkrow"
     },
     {
-        "id": 199,
+        "id": "199",
         "name": "Slowking"
     },
     {
-        "id": 200,
+        "id": "199_galar",
+        "name": "Galarian Slowking"
+    },
+    {
+        "id": "200",
         "name": "Misdreavus"
     },
     {
-        "id": 201,
+        "id": "201",
         "name": "Unown"
     },
     {
-        "id": 202,
+        "id": "201;0",
+        "name": "Unown A"
+    },
+    {
+        "id": "201;1",
+        "name": "Unown B"
+    },
+    {
+        "id": "201;2",
+        "name": "Unown C"
+    },
+    {
+        "id": "201;3",
+        "name": "Unown D"
+    },
+    {
+        "id": "201;4",
+        "name": "Unown E"
+    },
+    {
+        "id": "201;5",
+        "name": "Unown F"
+    },
+    {
+        "id": "201;6",
+        "name": "Unown G"
+    },
+    {
+        "id": "201;7",
+        "name": "Unown H"
+    },
+    {
+        "id": "201;8",
+        "name": "Unown I"
+    },
+    {
+        "id": "201;9",
+        "name": "Unown J"
+    },
+    {
+        "id": "201;10",
+        "name": "Unown K"
+    },
+    {
+        "id": "201;11",
+        "name": "Unown L"
+    },
+    {
+        "id": "201;12",
+        "name": "Unown M"
+    },
+    {
+        "id": "201;13",
+        "name": "Unown N"
+    },
+    {
+        "id": "201;14",
+        "name": "Unown O"
+    },
+    {
+        "id": "201;15",
+        "name": "Unown P"
+    },
+    {
+        "id": "201;16",
+        "name": "Unown Q"
+    },
+    {
+        "id": "201;17",
+        "name": "Unown R"
+    },
+    {
+        "id": "201;18",
+        "name": "Unown S"
+    },
+    {
+        "id": "201;19",
+        "name": "Unown T"
+    },
+    {
+        "id": "201;20",
+        "name": "Unown U"
+    },
+    {
+        "id": "201;21",
+        "name": "Unown V"
+    },
+    {
+        "id": "201;22",
+        "name": "Unown W"
+    },
+    {
+        "id": "201;23",
+        "name": "Unown X"
+    },
+    {
+        "id": "201;24",
+        "name": "Unown Y"
+    },
+    {
+        "id": "201;25",
+        "name": "Unown Z"
+    },
+    {
+        "id": "201;26",
+        "name": "Unown !"
+    },
+    {
+        "id": "201;27",
+        "name": "Unown ?"
+    },
+    {
+        "id": "202",
         "name": "Wobbuffet"
     },
     {
-        "id": 203,
+        "id": "203",
         "name": "Girafarig"
     },
     {
-        "id": 204,
+        "id": "204",
         "name": "Pineco"
     },
     {
-        "id": 205,
+        "id": "205",
         "name": "Forretress"
     },
     {
-        "id": 206,
+        "id": "206",
         "name": "Dunsparce"
     },
     {
-        "id": 207,
+        "id": "207",
         "name": "Gligar"
     },
     {
-        "id": 208,
+        "id": "208",
         "name": "Steelix"
     },
     {
-        "id": 209,
+        "id": "209",
         "name": "Snubbull"
     },
     {
-        "id": 210,
+        "id": "210",
         "name": "Granbull"
     },
     {
-        "id": 211,
+        "id": "211",
         "name": "Qwilfish"
     },
     {
-        "id": 212,
+        "id": "211_hisui",
+        "name": "Hisuian Qwilfish"
+    },
+    {
+        "id": "212",
         "name": "Scizor"
     },
     {
-        "id": 213,
+        "id": "213",
         "name": "Shuckle"
     },
     {
-        "id": 214,
+        "id": "214",
         "name": "Heracross"
     },
     {
-        "id": 215,
+        "id": "215",
         "name": "Sneasel"
     },
     {
-        "id": 216,
+        "id": "216",
         "name": "Teddiursa"
     },
     {
-        "id": 217,
+        "id": "217",
         "name": "Ursaring"
     },
     {
-        "id": 218,
+        "id": "218",
         "name": "Slugma"
     },
     {
-        "id": 219,
+        "id": "219",
         "name": "Magcargo"
     },
     {
-        "id": 220,
+        "id": "220",
         "name": "Swinub"
     },
     {
-        "id": 221,
+        "id": "221",
         "name": "Piloswine"
     },
     {
-        "id": 222,
+        "id": "222",
         "name": "Corsola"
     },
     {
-        "id": 223,
+        "id": "222_galar",
+        "name": "Galarian Corsola"
+    },
+    {
+        "id": "223",
         "name": "Remoraid"
     },
     {
-        "id": 224,
+        "id": "224",
         "name": "Octillery"
     },
     {
-        "id": 225,
+        "id": "225",
         "name": "Delibird"
     },
     {
-        "id": 226,
+        "id": "226",
         "name": "Mantine"
     },
     {
-        "id": 227,
+        "id": "227",
         "name": "Skarmory"
     },
     {
-        "id": 228,
+        "id": "228",
         "name": "Houndour"
     },
     {
-        "id": 229,
+        "id": "229",
         "name": "Houndoom"
     },
     {
-        "id": 230,
+        "id": "230",
         "name": "Kingdra"
     },
     {
-        "id": 231,
+        "id": "231",
         "name": "Phanpy"
     },
     {
-        "id": 232,
+        "id": "232",
         "name": "Donphan"
     },
     {
-        "id": 233,
+        "id": "233",
         "name": "Porygon2"
     },
     {
-        "id": 234,
+        "id": "234",
         "name": "Stantler"
     },
     {
-        "id": 235,
+        "id": "235",
         "name": "Smeargle"
     },
     {
-        "id": 236,
+        "id": "236",
         "name": "Tyrogue"
     },
     {
-        "id": 237,
+        "id": "237",
         "name": "Hitmontop"
     },
     {
-        "id": 238,
+        "id": "238",
         "name": "Smoochum"
     },
     {
-        "id": 239,
+        "id": "239",
         "name": "Elekid"
     },
     {
-        "id": 240,
+        "id": "240",
         "name": "Magby"
     },
     {
-        "id": 241,
+        "id": "241",
         "name": "Miltank"
     },
     {
-        "id": 242,
+        "id": "242",
         "name": "Blissey"
     },
     {
-        "id": 243,
+        "id": "243",
         "name": "Raikou"
     },
     {
-        "id": 244,
+        "id": "244",
         "name": "Entei"
     },
     {
-        "id": 245,
+        "id": "245",
         "name": "Suicune"
     },
     {
-        "id": 246,
+        "id": "246",
         "name": "Larvitar"
     },
     {
-        "id": 247,
+        "id": "247",
         "name": "Pupitar"
     },
     {
-        "id": 248,
+        "id": "248",
         "name": "Tyranitar"
     },
     {
-        "id": 249,
+        "id": "249",
         "name": "Lugia"
     },
     {
-        "id": 250,
+        "id": "250",
         "name": "Ho-oh"
     },
     {
-        "id": 251,
+        "id": "251",
         "name": "Celebi"
     },
     {
-        "id": 252,
+        "id": "252",
         "name": "Treecko"
     },
     {
-        "id": 253,
+        "id": "253",
         "name": "Grovyle"
     },
     {
-        "id": 254,
+        "id": "254",
         "name": "Sceptile"
     },
     {
-        "id": 255,
+        "id": "255",
         "name": "Torchic"
     },
     {
-        "id": 256,
+        "id": "256",
         "name": "Combusken"
     },
     {
-        "id": 257,
+        "id": "257",
         "name": "Blaziken"
     },
     {
-        "id": 258,
+        "id": "258",
         "name": "Mudkip"
     },
     {
-        "id": 259,
+        "id": "259",
         "name": "Marshtomp"
     },
     {
-        "id": 260,
+        "id": "260",
         "name": "Swampert"
     },
     {
-        "id": 261,
+        "id": "261",
         "name": "Poochyena"
     },
     {
-        "id": 262,
+        "id": "262",
         "name": "Mightyena"
     },
     {
-        "id": 263,
+        "id": "263",
         "name": "Zigzagoon"
     },
     {
-        "id": 264,
+        "id": "263_galar",
+        "name": "Galarian Zigzagoon"
+    },
+    {
+        "id": "264",
         "name": "Linoone"
     },
     {
-        "id": 265,
+        "id": "264_galar",
+        "name": "Galarian Linoone"
+    },
+    {
+        "id": "265",
         "name": "Wurmple"
     },
     {
-        "id": 266,
+        "id": "266",
         "name": "Silcoon"
     },
     {
-        "id": 267,
+        "id": "267",
         "name": "Beautifly"
     },
     {
-        "id": 268,
+        "id": "268",
         "name": "Cascoon"
     },
     {
-        "id": 269,
+        "id": "269",
         "name": "Dustox"
     },
     {
-        "id": 270,
+        "id": "270",
         "name": "Lotad"
     },
     {
-        "id": 271,
+        "id": "271",
         "name": "Lombre"
     },
     {
-        "id": 272,
+        "id": "272",
         "name": "Ludicolo"
     },
     {
-        "id": 273,
+        "id": "273",
         "name": "Seedot"
     },
     {
-        "id": 274,
+        "id": "274",
         "name": "Nuzleaf"
     },
     {
-        "id": 275,
+        "id": "275",
         "name": "Shiftry"
     },
     {
-        "id": 276,
+        "id": "276",
         "name": "Taillow"
     },
     {
-        "id": 277,
+        "id": "277",
         "name": "Swellow"
     },
     {
-        "id": 278,
+        "id": "278",
         "name": "Wingull"
     },
     {
-        "id": 279,
+        "id": "279",
         "name": "Pelipper"
     },
     {
-        "id": 280,
+        "id": "280",
         "name": "Ralts"
     },
     {
-        "id": 281,
+        "id": "281",
         "name": "Kirlia"
     },
     {
-        "id": 282,
+        "id": "282",
         "name": "Gardevoir"
     },
     {
-        "id": 283,
+        "id": "283",
         "name": "Surskit"
     },
     {
-        "id": 284,
+        "id": "284",
         "name": "Masquerain"
     },
     {
-        "id": 285,
+        "id": "285",
         "name": "Shroomish"
     },
     {
-        "id": 286,
+        "id": "286",
         "name": "Breloom"
     },
     {
-        "id": 287,
+        "id": "287",
         "name": "Slakoth"
     },
     {
-        "id": 288,
+        "id": "288",
         "name": "Vigoroth"
     },
     {
-        "id": 289,
+        "id": "289",
         "name": "Slaking"
     },
     {
-        "id": 290,
+        "id": "290",
         "name": "Nincada"
     },
     {
-        "id": 291,
+        "id": "291",
         "name": "Ninjask"
     },
     {
-        "id": 292,
+        "id": "292",
         "name": "Shedinja"
     },
     {
-        "id": 293,
+        "id": "293",
         "name": "Whismur"
     },
     {
-        "id": 294,
+        "id": "294",
         "name": "Loudred"
     },
     {
-        "id": 295,
+        "id": "295",
         "name": "Exploud"
     },
     {
-        "id": 296,
+        "id": "296",
         "name": "Makuhita"
     },
     {
-        "id": 297,
+        "id": "297",
         "name": "Hariyama"
     },
     {
-        "id": 298,
+        "id": "298",
         "name": "Azurill"
     },
     {
-        "id": 299,
+        "id": "299",
         "name": "Nosepass"
     },
     {
-        "id": 300,
+        "id": "300",
         "name": "Skitty"
     },
     {
-        "id": 301,
+        "id": "301",
         "name": "Delcatty"
     },
     {
-        "id": 302,
+        "id": "302",
         "name": "Sableye"
     },
     {
-        "id": 303,
+        "id": "303",
         "name": "Mawile"
     },
     {
-        "id": 304,
+        "id": "304",
         "name": "Aron"
     },
     {
-        "id": 305,
+        "id": "305",
         "name": "Lairon"
     },
     {
-        "id": 306,
+        "id": "306",
         "name": "Aggron"
     },
     {
-        "id": 307,
+        "id": "307",
         "name": "Meditite"
     },
     {
-        "id": 308,
+        "id": "308",
         "name": "Medicham"
     },
     {
-        "id": 309,
+        "id": "309",
         "name": "Electrike"
     },
     {
-        "id": 310,
+        "id": "310",
         "name": "Manectric"
     },
     {
-        "id": 311,
+        "id": "311",
         "name": "Plusle"
     },
     {
-        "id": 312,
+        "id": "312",
         "name": "Minun"
     },
     {
-        "id": 313,
+        "id": "313",
         "name": "Volbeat"
     },
     {
-        "id": 314,
+        "id": "314",
         "name": "Illumise"
     },
     {
-        "id": 315,
+        "id": "315",
         "name": "Roselia"
     },
     {
-        "id": 316,
+        "id": "316",
         "name": "Gulpin"
     },
     {
-        "id": 317,
+        "id": "317",
         "name": "Swalot"
     },
     {
-        "id": 318,
+        "id": "318",
         "name": "Carvanha"
     },
     {
-        "id": 319,
+        "id": "319",
         "name": "Sharpedo"
     },
     {
-        "id": 320,
+        "id": "320",
         "name": "Wailmer"
     },
     {
-        "id": 321,
+        "id": "321",
         "name": "Wailord"
     },
     {
-        "id": 322,
+        "id": "322",
         "name": "Numel"
     },
     {
-        "id": 323,
+        "id": "323",
         "name": "Camerupt"
     },
     {
-        "id": 324,
+        "id": "324",
         "name": "Torkoal"
     },
     {
-        "id": 325,
+        "id": "325",
         "name": "Spoink"
     },
     {
-        "id": 326,
+        "id": "326",
         "name": "Grumpig"
     },
     {
-        "id": 327,
+        "id": "327",
         "name": "Spinda"
     },
     {
-        "id": 328,
+        "id": "328",
         "name": "Trapinch"
     },
     {
-        "id": 329,
+        "id": "329",
         "name": "Vibrava"
     },
     {
-        "id": 330,
+        "id": "330",
         "name": "Flygon"
     },
     {
-        "id": 331,
+        "id": "331",
         "name": "Cacnea"
     },
     {
-        "id": 332,
+        "id": "332",
         "name": "Cacturne"
     },
     {
-        "id": 333,
+        "id": "333",
         "name": "Swablu"
     },
     {
-        "id": 334,
+        "id": "334",
         "name": "Altaria"
     },
     {
-        "id": 335,
+        "id": "335",
         "name": "Zangoose"
     },
     {
-        "id": 336,
+        "id": "336",
         "name": "Seviper"
     },
     {
-        "id": 337,
+        "id": "337",
         "name": "Lunatone"
     },
     {
-        "id": 338,
+        "id": "338",
         "name": "Solrock"
     },
     {
-        "id": 339,
+        "id": "339",
         "name": "Barboach"
     },
     {
-        "id": 340,
+        "id": "340",
         "name": "Whiscash"
     },
     {
-        "id": 341,
+        "id": "341",
         "name": "Corphish"
     },
     {
-        "id": 342,
+        "id": "342",
         "name": "Crawdaunt"
     },
     {
-        "id": 343,
+        "id": "343",
         "name": "Baltoy"
     },
     {
-        "id": 344,
+        "id": "344",
         "name": "Claydol"
     },
     {
-        "id": 345,
+        "id": "345",
         "name": "Lileep"
     },
     {
-        "id": 346,
+        "id": "346",
         "name": "Cradily"
     },
     {
-        "id": 347,
+        "id": "347",
         "name": "Anorith"
     },
     {
-        "id": 348,
+        "id": "348",
         "name": "Armaldo"
     },
     {
-        "id": 349,
+        "id": "349",
         "name": "Feebas"
     },
     {
-        "id": 350,
+        "id": "350",
         "name": "Milotic"
     },
     {
-        "id": 351,
+        "id": "351",
         "name": "Castform"
     },
     {
-        "id": 352,
+        "id": "352",
         "name": "Kecleon"
     },
     {
-        "id": 353,
+        "id": "353",
         "name": "Shuppet"
     },
     {
-        "id": 354,
+        "id": "354",
         "name": "Banette"
     },
     {
-        "id": 355,
+        "id": "355",
         "name": "Duskull"
     },
     {
-        "id": 356,
+        "id": "356",
         "name": "Dusclops"
     },
     {
-        "id": 357,
+        "id": "357",
         "name": "Tropius"
     },
     {
-        "id": 358,
+        "id": "358",
         "name": "Chimecho"
     },
     {
-        "id": 359,
+        "id": "359",
         "name": "Absol"
     },
     {
-        "id": 360,
+        "id": "360",
         "name": "Wynaut"
     },
     {
-        "id": 361,
+        "id": "361",
         "name": "Snorunt"
     },
     {
-        "id": 362,
+        "id": "362",
         "name": "Glalie"
     },
     {
-        "id": 363,
+        "id": "363",
         "name": "Spheal"
     },
     {
-        "id": 364,
+        "id": "364",
         "name": "Sealeo"
     },
     {
-        "id": 365,
+        "id": "365",
         "name": "Walrein"
     },
     {
-        "id": 366,
+        "id": "366",
         "name": "Clamperl"
     },
     {
-        "id": 367,
+        "id": "367",
         "name": "Huntail"
     },
     {
-        "id": 368,
+        "id": "368",
         "name": "Gorebyss"
     },
     {
-        "id": 369,
+        "id": "369",
         "name": "Relicanth"
     },
     {
-        "id": 370,
+        "id": "370",
         "name": "Luvdisc"
     },
     {
-        "id": 371,
+        "id": "371",
         "name": "Bagon"
     },
     {
-        "id": 372,
+        "id": "372",
         "name": "Shelgon"
     },
     {
-        "id": 373,
+        "id": "373",
         "name": "Salamence"
     },
     {
-        "id": 374,
+        "id": "374",
         "name": "Beldum"
     },
     {
-        "id": 375,
+        "id": "375",
         "name": "Metang"
     },
     {
-        "id": 376,
+        "id": "376",
         "name": "Metagross"
     },
     {
-        "id": 377,
+        "id": "377",
         "name": "Regirock"
     },
     {
-        "id": 378,
+        "id": "378",
         "name": "Regice"
     },
     {
-        "id": 379,
+        "id": "379",
         "name": "Registeel"
     },
     {
-        "id": 380,
+        "id": "380",
         "name": "Latias"
     },
     {
-        "id": 381,
+        "id": "381",
         "name": "Latios"
     },
     {
-        "id": 382,
+        "id": "382",
         "name": "Kyogre"
     },
     {
-        "id": 383,
+        "id": "383",
         "name": "Groudon"
     },
     {
-        "id": 384,
+        "id": "384",
         "name": "Rayquaza"
     },
     {
-        "id": 385,
+        "id": "385",
         "name": "Jirachi"
     },
     {
-        "id": 386,
+        "id": "386",
         "name": "Deoxys"
     },
     {
-        "id": 387,
+        "id": "387",
         "name": "Turtwig"
     },
     {
-        "id": 388,
+        "id": "388",
         "name": "Grotle"
     },
     {
-        "id": 389,
+        "id": "389",
         "name": "Torterra"
     },
     {
-        "id": 390,
+        "id": "390",
         "name": "Chimchar"
     },
     {
-        "id": 391,
+        "id": "391",
         "name": "Monferno"
     },
     {
-        "id": 392,
+        "id": "392",
         "name": "Infernape"
     },
     {
-        "id": 393,
+        "id": "393",
         "name": "Piplup"
     },
     {
-        "id": 394,
+        "id": "394",
         "name": "Prinplup"
     },
     {
-        "id": 395,
+        "id": "395",
         "name": "Empoleon"
     },
     {
-        "id": 396,
+        "id": "396",
         "name": "Starly"
     },
     {
-        "id": 397,
+        "id": "397",
         "name": "Staravia"
     },
     {
-        "id": 398,
+        "id": "398",
         "name": "Staraptor"
     },
     {
-        "id": 399,
+        "id": "399",
         "name": "Bidoof"
     },
     {
-        "id": 400,
+        "id": "400",
         "name": "Bibarel"
     },
     {
-        "id": 401,
+        "id": "401",
         "name": "Kricketot"
     },
     {
-        "id": 402,
+        "id": "402",
         "name": "Kricketune"
     },
     {
-        "id": 403,
+        "id": "403",
         "name": "Shinx"
     },
     {
-        "id": 404,
+        "id": "404",
         "name": "Luxio"
     },
     {
-        "id": 405,
+        "id": "405",
         "name": "Luxray"
     },
     {
-        "id": 406,
+        "id": "406",
         "name": "Budew"
     },
     {
-        "id": 407,
+        "id": "407",
         "name": "Roserade"
     },
     {
-        "id": 408,
+        "id": "408",
         "name": "Cranidos"
     },
     {
-        "id": 409,
+        "id": "409",
         "name": "Rampardos"
     },
     {
-        "id": 410,
+        "id": "410",
         "name": "Shieldon"
     },
     {
-        "id": 411,
+        "id": "411",
         "name": "Bastiodon"
     },
     {
-        "id": 412,
+        "id": "412",
         "name": "Burmy"
     },
     {
-        "id": 413,
+        "id": "413",
         "name": "Wormadam"
     },
     {
-        "id": 414,
+        "id": "414",
         "name": "Mothim"
     },
     {
-        "id": 415,
+        "id": "415",
         "name": "Combee"
     },
     {
-        "id": 416,
+        "id": "416",
         "name": "Vespiquen"
     },
     {
-        "id": 417,
+        "id": "417",
         "name": "Pachirisu"
     },
     {
-        "id": 418,
+        "id": "418",
         "name": "Buizel"
     },
     {
-        "id": 419,
+        "id": "419",
         "name": "Floatzel"
     },
     {
-        "id": 420,
+        "id": "420",
         "name": "Cherubi"
     },
     {
-        "id": 421,
+        "id": "421",
         "name": "Cherrim"
     },
     {
-        "id": 422,
+        "id": "422",
         "name": "Shellos"
     },
     {
-        "id": 423,
+        "id": "423",
         "name": "Gastrodon"
     },
     {
-        "id": 424,
+        "id": "424",
         "name": "Ambipom"
     },
     {
-        "id": 425,
+        "id": "425",
         "name": "Drifloon"
     },
     {
-        "id": 426,
+        "id": "426",
         "name": "Drifblim"
     },
     {
-        "id": 427,
+        "id": "427",
         "name": "Buneary"
     },
     {
-        "id": 428,
+        "id": "428",
         "name": "Lopunny"
     },
     {
-        "id": 429,
+        "id": "429",
         "name": "Mismagius"
     },
     {
-        "id": 430,
+        "id": "430",
         "name": "Honchkrow"
     },
     {
-        "id": 431,
+        "id": "431",
         "name": "Glameow"
     },
     {
-        "id": 432,
+        "id": "432",
         "name": "Purugly"
     },
     {
-        "id": 433,
+        "id": "433",
         "name": "Chingling"
     },
     {
-        "id": 434,
+        "id": "434",
         "name": "Stunky"
     },
     {
-        "id": 435,
+        "id": "435",
         "name": "Skuntank"
     },
     {
-        "id": 436,
+        "id": "436",
         "name": "Bronzor"
     },
     {
-        "id": 437,
+        "id": "437",
         "name": "Bronzong"
     },
     {
-        "id": 438,
+        "id": "438",
         "name": "Bonsly"
     },
     {
-        "id": 439,
+        "id": "439",
         "name": "Mime Jr."
     },
     {
-        "id": 440,
+        "id": "440",
         "name": "Happiny"
     },
     {
-        "id": 441,
+        "id": "441",
         "name": "Chatot"
     },
     {
-        "id": 442,
+        "id": "442",
         "name": "Spiritomb"
     },
     {
-        "id": 443,
+        "id": "443",
         "name": "Gible"
     },
     {
-        "id": 444,
+        "id": "444",
         "name": "Gabite"
     },
     {
-        "id": 445,
+        "id": "445",
         "name": "Garchomp"
     },
     {
-        "id": 446,
+        "id": "446",
         "name": "Munchlax"
     },
     {
-        "id": 447,
+        "id": "447",
         "name": "Riolu"
     },
     {
-        "id": 448,
+        "id": "448",
         "name": "Lucario"
     },
     {
-        "id": 449,
+        "id": "449",
         "name": "Hippopotas"
     },
     {
-        "id": 450,
+        "id": "450",
         "name": "Hippowdon"
     },
     {
-        "id": 451,
+        "id": "451",
         "name": "Skorupi"
     },
     {
-        "id": 452,
+        "id": "452",
         "name": "Drapion"
     },
     {
-        "id": 453,
+        "id": "453",
         "name": "Croagunk"
     },
     {
-        "id": 454,
+        "id": "454",
         "name": "Toxicroak"
     },
     {
-        "id": 455,
+        "id": "455",
         "name": "Carnivine"
     },
     {
-        "id": 456,
+        "id": "456",
         "name": "Finneon"
     },
     {
-        "id": 457,
+        "id": "457",
         "name": "Lumineon"
     },
     {
-        "id": 458,
+        "id": "458",
         "name": "Mantyke"
     },
     {
-        "id": 459,
+        "id": "459",
         "name": "Snover"
     },
     {
-        "id": 460,
+        "id": "460",
         "name": "Abomasnow"
     },
     {
-        "id": 461,
+        "id": "461",
         "name": "Weavile"
     },
     {
-        "id": 462,
+        "id": "462",
         "name": "Magnezone"
     },
     {
-        "id": 463,
+        "id": "463",
         "name": "Lickilicky"
     },
     {
-        "id": 464,
+        "id": "464",
         "name": "Rhyperior"
     },
     {
-        "id": 465,
+        "id": "465",
         "name": "Tangrowth"
     },
     {
-        "id": 466,
+        "id": "466",
         "name": "Electivire"
     },
     {
-        "id": 467,
+        "id": "467",
         "name": "Magmortar"
     },
     {
-        "id": 468,
+        "id": "468",
         "name": "Togekiss"
     },
     {
-        "id": 469,
+        "id": "469",
         "name": "Yanmega"
     },
     {
-        "id": 470,
+        "id": "470",
         "name": "Leafeon"
     },
     {
-        "id": 471,
+        "id": "471",
         "name": "Glaceon"
     },
     {
-        "id": 472,
+        "id": "472",
         "name": "Gliscor"
     },
     {
-        "id": 473,
+        "id": "473",
         "name": "Mamoswine"
     },
     {
-        "id": 474,
+        "id": "474",
         "name": "Porygon-Z"
     },
     {
-        "id": 475,
+        "id": "475",
         "name": "Gallade"
     },
     {
-        "id": 476,
+        "id": "476",
         "name": "Probopass"
     },
     {
-        "id": 477,
+        "id": "477",
         "name": "Dusknoir"
     },
     {
-        "id": 478,
+        "id": "478",
         "name": "Froslass"
     },
     {
-        "id": 479,
+        "id": "479",
         "name": "Rotom"
     },
     {
-        "id": 480,
+        "id": "480",
         "name": "Uxie"
     },
     {
-        "id": 481,
+        "id": "481",
         "name": "Mesprit"
     },
     {
-        "id": 482,
+        "id": "482",
         "name": "Azelf"
     },
     {
-        "id": 483,
+        "id": "483",
         "name": "Dialga"
     },
     {
-        "id": 484,
+        "id": "484",
         "name": "Palkia"
     },
     {
-        "id": 485,
+        "id": "485",
         "name": "Heatran"
     },
     {
-        "id": 486,
+        "id": "486",
         "name": "Regigigas"
     },
     {
-        "id": 487,
+        "id": "487",
         "name": "Giratina"
     },
     {
-        "id": 488,
+        "id": "488",
         "name": "Cresselia"
     },
     {
-        "id": 489,
+        "id": "489",
         "name": "Phione"
     },
     {
-        "id": 490,
+        "id": "490",
         "name": "Manaphy"
     },
     {
-        "id": 491,
+        "id": "491",
         "name": "Darkrai"
     },
     {
-        "id": 492,
+        "id": "492",
         "name": "Shaymin"
     },
     {
-        "id": 493,
+        "id": "493",
         "name": "Arceus"
     },
     {
-        "id": 494,
+        "id": "494",
         "name": "Victini"
     },
     {
-        "id": 495,
+        "id": "495",
         "name": "Snivy"
     },
     {
-        "id": 496,
+        "id": "496",
         "name": "Servine"
     },
     {
-        "id": 497,
+        "id": "497",
         "name": "Serperior"
     },
     {
-        "id": 498,
+        "id": "498",
         "name": "Tepig"
     },
     {
-        "id": 499,
+        "id": "499",
         "name": "Pignite"
     },
     {
-        "id": 500,
+        "id": "500",
         "name": "Emboar"
     },
     {
-        "id": 501,
+        "id": "501",
         "name": "Oshawott"
     },
     {
-        "id": 502,
+        "id": "502",
         "name": "Dewott"
     },
     {
-        "id": 503,
+        "id": "503",
         "name": "Samurott"
     },
     {
-        "id": 504,
+        "id": "504",
         "name": "Patrat"
     },
     {
-        "id": 505,
+        "id": "505",
         "name": "Watchog"
     },
     {
-        "id": 506,
+        "id": "506",
         "name": "Lillipup"
     },
     {
-        "id": 507,
+        "id": "507",
         "name": "Herdier"
     },
     {
-        "id": 508,
+        "id": "508",
         "name": "Stoutland"
     },
     {
-        "id": 509,
+        "id": "509",
         "name": "Purrloin"
     },
     {
-        "id": 510,
+        "id": "510",
         "name": "Liepard"
     },
     {
-        "id": 511,
+        "id": "511",
         "name": "Pansage"
     },
     {
-        "id": 512,
+        "id": "512",
         "name": "Simisage"
     },
     {
-        "id": 513,
+        "id": "513",
         "name": "Pansear"
     },
     {
-        "id": 514,
+        "id": "514",
         "name": "Simisear"
     },
     {
-        "id": 515,
+        "id": "515",
         "name": "Panpour"
     },
     {
-        "id": 516,
+        "id": "516",
         "name": "Simipour"
     },
     {
-        "id": 517,
+        "id": "517",
         "name": "Munna"
     },
     {
-        "id": 518,
+        "id": "518",
         "name": "Musharna"
     },
     {
-        "id": 519,
+        "id": "519",
         "name": "Pidove"
     },
     {
-        "id": 520,
+        "id": "520",
         "name": "Tranquill"
     },
     {
-        "id": 521,
+        "id": "521",
         "name": "Unfezant"
     },
     {
-        "id": 522,
+        "id": "522",
         "name": "Blitzle"
     },
     {
-        "id": 523,
+        "id": "523",
         "name": "Zebstrika"
     },
     {
-        "id": 524,
+        "id": "524",
         "name": "Roggenrola"
     },
     {
-        "id": 525,
+        "id": "525",
         "name": "Boldore"
     },
     {
-        "id": 526,
+        "id": "526",
         "name": "Gigalith"
     },
     {
-        "id": 527,
+        "id": "527",
         "name": "Woobat"
     },
     {
-        "id": 528,
+        "id": "528",
         "name": "Swoobat"
     },
     {
-        "id": 529,
+        "id": "529",
         "name": "Drilbur"
     },
     {
-        "id": 530,
+        "id": "530",
         "name": "Excadrill"
     },
     {
-        "id": 531,
+        "id": "531",
         "name": "Audino"
     },
     {
-        "id": 532,
+        "id": "532",
         "name": "Timburr"
     },
     {
-        "id": 533,
+        "id": "533",
         "name": "Gurdurr"
     },
     {
-        "id": 534,
+        "id": "534",
         "name": "Conkeldurr"
     },
     {
-        "id": 535,
+        "id": "535",
         "name": "Tympole"
     },
     {
-        "id": 536,
+        "id": "536",
         "name": "Palpitoad"
     },
     {
-        "id": 537,
+        "id": "537",
         "name": "Seismitoad"
     },
     {
-        "id": 538,
+        "id": "538",
         "name": "Throh"
     },
     {
-        "id": 539,
+        "id": "539",
         "name": "Sawk"
     },
     {
-        "id": 540,
+        "id": "540",
         "name": "Sewaddle"
     },
     {
-        "id": 541,
+        "id": "541",
         "name": "Swadloon"
     },
     {
-        "id": 542,
+        "id": "542",
         "name": "Leavanny"
     },
     {
-        "id": 543,
+        "id": "543",
         "name": "Venipede"
     },
     {
-        "id": 544,
+        "id": "544",
         "name": "Whirlipede"
     },
     {
-        "id": 545,
+        "id": "545",
         "name": "Scolipede"
     },
     {
-        "id": 546,
+        "id": "546",
         "name": "Cottonee"
     },
     {
-        "id": 547,
+        "id": "547",
         "name": "Whimsicott"
     },
     {
-        "id": 548,
+        "id": "548",
         "name": "Petilil"
     },
     {
-        "id": 549,
+        "id": "549",
         "name": "Lilligant"
     },
     {
-        "id": 550,
+        "id": "549_hisui",
+        "name": "Hisuian Lilligant"
+    },
+    {
+        "id": "550",
         "name": "Basculin"
     },
     {
-        "id": 551,
+        "id": "551",
         "name": "Sandile"
     },
     {
-        "id": 552,
+        "id": "552",
         "name": "Krokorok"
     },
     {
-        "id": 553,
+        "id": "553",
         "name": "Krookodile"
     },
     {
-        "id": 554,
+        "id": "554",
         "name": "Darumaka"
     },
     {
-        "id": 555,
+        "id": "554_galar",
+        "name": "Galarian Darumaka"
+    },
+    {
+        "id": "555",
         "name": "Darmanitan"
     },
     {
-        "id": 556,
+        "id": "555_galar",
+        "name": "Galarian Darmanitan"
+    },
+    {
+        "id": "556",
         "name": "Maractus"
     },
     {
-        "id": 557,
+        "id": "557",
         "name": "Dwebble"
     },
     {
-        "id": 558,
+        "id": "558",
         "name": "Crustle"
     },
     {
-        "id": 559,
+        "id": "559",
         "name": "Scraggy"
     },
     {
-        "id": 560,
+        "id": "560",
         "name": "Scrafty"
     },
     {
-        "id": 561,
+        "id": "561",
         "name": "Sigilyph"
     },
     {
-        "id": 562,
+        "id": "562",
         "name": "Yamask"
     },
     {
-        "id": 563,
+        "id": "562_galar",
+        "name": "Galarian Yamask"
+    },
+    {
+        "id": "563",
         "name": "Cofagrigus"
     },
     {
-        "id": 564,
+        "id": "564",
         "name": "Tirtouga"
     },
     {
-        "id": 565,
+        "id": "565",
         "name": "Carracosta"
     },
     {
-        "id": 566,
+        "id": "566",
         "name": "Archen"
     },
     {
-        "id": 567,
+        "id": "567",
         "name": "Archeops"
     },
     {
-        "id": 568,
+        "id": "568",
         "name": "Trubbish"
     },
     {
-        "id": 569,
+        "id": "569",
         "name": "Garbodor"
     },
     {
-        "id": 570,
+        "id": "570",
         "name": "Zorua"
     },
     {
-        "id": 571,
+        "id": "570_hisui",
+        "name": "Hisuian Zorua"
+    },
+    {
+        "id": "571",
         "name": "Zoroark"
     },
     {
-        "id": 572,
+        "id": "571_hisui",
+        "name": "Hisuian Zoroark"
+    },
+    {
+        "id": "572",
         "name": "Minccino"
     },
     {
-        "id": 573,
+        "id": "573",
         "name": "Cinccino"
     },
     {
-        "id": 574,
+        "id": "574",
         "name": "Gothita"
     },
     {
-        "id": 575,
+        "id": "575",
         "name": "Gothorita"
     },
     {
-        "id": 576,
+        "id": "576",
         "name": "Gothitelle"
     },
     {
-        "id": 577,
+        "id": "577",
         "name": "Solosis"
     },
     {
-        "id": 578,
+        "id": "578",
         "name": "Duosion"
     },
     {
-        "id": 579,
+        "id": "579",
         "name": "Reuniclus"
     },
     {
-        "id": 580,
+        "id": "580",
         "name": "Ducklett"
     },
     {
-        "id": 581,
+        "id": "581",
         "name": "Swanna"
     },
     {
-        "id": 582,
+        "id": "582",
         "name": "Vanillite"
     },
     {
-        "id": 583,
+        "id": "583",
         "name": "Vanillish"
     },
     {
-        "id": 584,
+        "id": "584",
         "name": "Vanilluxe"
     },
     {
-        "id": 585,
+        "id": "585",
         "name": "Deerling"
     },
     {
-        "id": 586,
+        "id": "586",
         "name": "Sawsbuck"
     },
     {
-        "id": 587,
+        "id": "587",
         "name": "Emolga"
     },
     {
-        "id": 588,
+        "id": "588",
         "name": "Karrablast"
     },
     {
-        "id": 589,
+        "id": "589",
         "name": "Escavalier"
     },
     {
-        "id": 590,
+        "id": "590",
         "name": "Foongus"
     },
     {
-        "id": 591,
+        "id": "591",
         "name": "Amoonguss"
     },
     {
-        "id": 592,
+        "id": "592",
         "name": "Frillish"
     },
     {
-        "id": 593,
+        "id": "593",
         "name": "Jellicent"
     },
     {
-        "id": 594,
+        "id": "594",
         "name": "Alomomola"
     },
     {
-        "id": 595,
+        "id": "595",
         "name": "Joltik"
     },
     {
-        "id": 596,
+        "id": "596",
         "name": "Galvantula"
     },
     {
-        "id": 597,
+        "id": "597",
         "name": "Ferroseed"
     },
     {
-        "id": 598,
+        "id": "598",
         "name": "Ferrothorn"
     },
     {
-        "id": 599,
+        "id": "599",
         "name": "Klink"
     },
     {
-        "id": 600,
+        "id": "600",
         "name": "Klang"
     },
     {
-        "id": 601,
+        "id": "601",
         "name": "Klinklang"
     },
     {
-        "id": 602,
+        "id": "602",
         "name": "Tynamo"
     },
     {
-        "id": 603,
+        "id": "603",
         "name": "Eelektrik"
     },
     {
-        "id": 604,
+        "id": "604",
         "name": "Eelektross"
     },
     {
-        "id": 605,
+        "id": "605",
         "name": "Elgyem"
     },
     {
-        "id": 606,
+        "id": "606",
         "name": "Beheeyem"
     },
     {
-        "id": 607,
+        "id": "607",
         "name": "Litwick"
     },
     {
-        "id": 608,
+        "id": "608",
         "name": "Lampent"
     },
     {
-        "id": 609,
+        "id": "609",
         "name": "Chandelure"
     },
     {
-        "id": 610,
+        "id": "610",
         "name": "Axew"
     },
     {
-        "id": 611,
+        "id": "611",
         "name": "Fraxure"
     },
     {
-        "id": 612,
+        "id": "612",
         "name": "Haxorus"
     },
     {
-        "id": 613,
+        "id": "613",
         "name": "Cubchoo"
     },
     {
-        "id": 614,
+        "id": "614",
         "name": "Beartic"
     },
     {
-        "id": 615,
+        "id": "615",
         "name": "Cryogonal"
     },
     {
-        "id": 616,
+        "id": "616",
         "name": "Shelmet"
     },
     {
-        "id": 617,
+        "id": "617",
         "name": "Accelgor"
     },
     {
-        "id": 618,
+        "id": "618",
         "name": "Stunfisk"
     },
     {
-        "id": 619,
+        "id": "618_galar",
+        "name": "Galarian Stunfisk"
+    },
+    {
+        "id": "619",
         "name": "Mienfoo"
     },
     {
-        "id": 620,
+        "id": "620",
         "name": "Mienshao"
     },
     {
-        "id": 621,
+        "id": "621",
         "name": "Druddigon"
     },
     {
-        "id": 622,
+        "id": "622",
         "name": "Golett"
     },
     {
-        "id": 623,
+        "id": "623",
         "name": "Golurk"
     },
     {
-        "id": 624,
+        "id": "624",
         "name": "Pawniard"
     },
     {
-        "id": 625,
+        "id": "625",
         "name": "Bisharp"
     },
     {
-        "id": 626,
+        "id": "626",
         "name": "Bouffalant"
     },
     {
-        "id": 627,
+        "id": "627",
         "name": "Rufflet"
     },
     {
-        "id": 628,
+        "id": "628",
         "name": "Braviary"
     },
     {
-        "id": 629,
+        "id": "628_hisui",
+        "name": "Hisuian Braviary"
+    },
+    {
+        "id": "629",
         "name": "Vullaby"
     },
     {
-        "id": 630,
+        "id": "630",
         "name": "Mandibuzz"
     },
     {
-        "id": 631,
+        "id": "631",
         "name": "Heatmor"
     },
     {
-        "id": 632,
+        "id": "632",
         "name": "Durant"
     },
     {
-        "id": 633,
+        "id": "633",
         "name": "Deino"
     },
     {
-        "id": 634,
+        "id": "634",
         "name": "Zweilous"
     },
     {
-        "id": 635,
+        "id": "635",
         "name": "Hydreigon"
     },
     {
-        "id": 636,
+        "id": "636",
         "name": "Larvesta"
     },
     {
-        "id": 637,
+        "id": "637",
         "name": "Volcarona"
     },
     {
-        "id": 638,
+        "id": "638",
         "name": "Cobalion"
     },
     {
-        "id": 639,
+        "id": "639",
         "name": "Terrakion"
     },
     {
-        "id": 640,
+        "id": "640",
         "name": "Virizion"
     },
     {
-        "id": 641,
+        "id": "641",
         "name": "Tornadus"
     },
     {
-        "id": 642,
+        "id": "642",
         "name": "Thundurus"
     },
     {
-        "id": 643,
+        "id": "643",
         "name": "Reshiram"
     },
     {
-        "id": 644,
+        "id": "644",
         "name": "Zekrom"
     },
     {
-        "id": 645,
+        "id": "645",
         "name": "Landorus"
     },
     {
-        "id": 646,
+        "id": "646",
         "name": "Kyurem"
     },
     {
-        "id": 647,
+        "id": "647",
         "name": "Keldeo"
     },
     {
-        "id": 648,
+        "id": "648",
         "name": "Meloetta"
     },
     {
-        "id": 649,
+        "id": "649",
         "name": "Genesect"
     },
     {
-        "id": 650,
+        "id": "650",
         "name": "Chespin"
     },
     {
-        "id": 651,
+        "id": "651",
         "name": "Quilladin"
     },
     {
-        "id": 652,
+        "id": "652",
         "name": "Chesnaught"
     },
     {
-        "id": 653,
+        "id": "653",
         "name": "Fennekin"
     },
     {
-        "id": 654,
+        "id": "654",
         "name": "Braixen"
     },
     {
-        "id": 655,
+        "id": "655",
         "name": "Delphox"
     },
     {
-        "id": 656,
+        "id": "656",
         "name": "Froakie"
     },
     {
-        "id": 657,
+        "id": "657",
         "name": "Frogadier"
     },
     {
-        "id": 658,
+        "id": "658",
         "name": "Greninja"
     },
     {
-        "id": 659,
+        "id": "659",
         "name": "Bunnelby"
     },
     {
-        "id": 660,
+        "id": "660",
         "name": "Diggersby"
     },
     {
-        "id": 661,
+        "id": "661",
         "name": "Fletchling"
     },
     {
-        "id": 662,
+        "id": "662",
         "name": "Fletchinder"
     },
     {
-        "id": 663,
+        "id": "663",
         "name": "Talonflame"
     },
     {
-        "id": 664,
+        "id": "664",
         "name": "Scatterbug"
     },
     {
-        "id": 665,
+        "id": "665",
         "name": "Spewpa"
     },
     {
-        "id": 666,
+        "id": "666",
         "name": "Vivillon"
     },
     {
-        "id": 667,
+        "id": "667",
         "name": "Litleo"
     },
     {
-        "id": 668,
+        "id": "668",
         "name": "Pyroar"
     },
     {
-        "id": 669,
+        "id": "669",
         "name": "Flabébé"
     },
     {
-        "id": 670,
+        "id": "670",
         "name": "Floette"
     },
     {
-        "id": 671,
+        "id": "671",
         "name": "Florges"
     },
     {
-        "id": 672,
+        "id": "672",
         "name": "Skiddo"
     },
     {
-        "id": 673,
+        "id": "673",
         "name": "Gogoat"
     },
     {
-        "id": 674,
+        "id": "674",
         "name": "Pancham"
     },
     {
-        "id": 675,
+        "id": "675",
         "name": "Pangoro"
     },
     {
-        "id": 676,
+        "id": "676",
         "name": "Furfrou"
     },
     {
-        "id": 677,
+        "id": "677",
         "name": "Espurr"
     },
     {
-        "id": 678,
+        "id": "678",
         "name": "Meowstic"
     },
     {
-        "id": 679,
+        "id": "679",
         "name": "Honedge"
     },
     {
-        "id": 680,
+        "id": "680",
         "name": "Doublade"
     },
     {
-        "id": 681,
+        "id": "681",
         "name": "Aegislash"
     },
     {
-        "id": 682,
+        "id": "682",
         "name": "Spritzee"
     },
     {
-        "id": 683,
+        "id": "683",
         "name": "Aromatisse"
     },
     {
-        "id": 684,
+        "id": "684",
         "name": "Swirlix"
     },
     {
-        "id": 685,
+        "id": "685",
         "name": "Slurpuff"
     },
     {
-        "id": 686,
+        "id": "686",
         "name": "Inkay"
     },
     {
-        "id": 687,
+        "id": "687",
         "name": "Malamar"
     },
     {
-        "id": 688,
+        "id": "688",
         "name": "Binacle"
     },
     {
-        "id": 689,
+        "id": "689",
         "name": "Barbaracle"
     },
     {
-        "id": 690,
+        "id": "690",
         "name": "Skrelp"
     },
     {
-        "id": 691,
+        "id": "691",
         "name": "Dragalge"
     },
     {
-        "id": 692,
+        "id": "692",
         "name": "Clauncher"
     },
     {
-        "id": 693,
+        "id": "693",
         "name": "Clawitzer"
     },
     {
-        "id": 694,
+        "id": "694",
         "name": "Helioptile"
     },
     {
-        "id": 695,
+        "id": "695",
         "name": "Heliolisk"
     },
     {
-        "id": 696,
+        "id": "696",
         "name": "Tyrunt"
     },
     {
-        "id": 697,
+        "id": "697",
         "name": "Tyrantrum"
     },
     {
-        "id": 698,
+        "id": "698",
         "name": "Amaura"
     },
     {
-        "id": 699,
+        "id": "699",
         "name": "Aurorus"
     },
     {
-        "id": 700,
+        "id": "700",
         "name": "Sylveon"
     },
     {
-        "id": 701,
+        "id": "701",
         "name": "Hawlucha"
     },
     {
-        "id": 702,
+        "id": "702",
         "name": "Dedenne"
     },
     {
-        "id": 703,
+        "id": "703",
         "name": "Carbink"
     },
     {
-        "id": 704,
+        "id": "704",
         "name": "Goomy"
     },
     {
-        "id": 705,
+        "id": "705",
         "name": "Sliggoo"
     },
     {
-        "id": 706,
+        "id": "705_hisui",
+        "name": "Hisuian Sliggoo"
+    },
+    {
+        "id": "706",
         "name": "Goodra"
     },
     {
-        "id": 707,
+        "id": "706_hisui",
+        "name": "Hisuian Goodra"
+    },
+    {
+        "id": "707",
         "name": "Klefki"
     },
     {
-        "id": 708,
+        "id": "708",
         "name": "Phantump"
     },
     {
-        "id": 709,
+        "id": "709",
         "name": "Trevenant"
     },
     {
-        "id": 710,
+        "id": "710",
         "name": "Pumpkaboo"
     },
     {
-        "id": 711,
+        "id": "711",
         "name": "Gourgeist"
     },
     {
-        "id": 712,
+        "id": "712",
         "name": "Bergmite"
     },
     {
-        "id": 713,
+        "id": "713",
         "name": "Avalugg"
     },
     {
-        "id": 714,
+        "id": "713_hisui",
+        "name": "Hisuian Goodra"
+    },
+    {
+        "id": "714",
         "name": "Noibat"
     },
     {
-        "id": 715,
+        "id": "715",
         "name": "Noivern"
     },
     {
-        "id": 716,
+        "id": "716",
         "name": "Xerneas"
     },
     {
-        "id": 717,
+        "id": "717",
         "name": "Yveltal"
     },
     {
-        "id": 718,
+        "id": "718",
         "name": "Zygarde"
     },
     {
-        "id": 719,
+        "id": "719",
         "name": "Diancie"
     },
     {
-        "id": 720,
+        "id": "720",
         "name": "Hoopa"
     },
     {
-        "id": 721,
+        "id": "721",
         "name": "Volcanion"
     },
     {
-        "id": 722,
+        "id": "722",
         "name": "Rowlet"
     },
     {
-        "id": 723,
+        "id": "723",
         "name": "Dartrix"
     },
     {
-        "id": 724,
+        "id": "724",
         "name": "Decidueye"
     },
     {
-        "id": 725,
+        "id": "724_hisui",
+        "name": "Hisuian Decidueye"
+    },
+    {
+        "id": "725",
         "name": "Litten"
     },
     {
-        "id": 726,
+        "id": "726",
         "name": "Torracat"
     },
     {
-        "id": 727,
+        "id": "727",
         "name": "Incineroar"
     },
     {
-        "id": 728,
+        "id": "728",
         "name": "Popplio"
     },
     {
-        "id": 729,
+        "id": "729",
         "name": "Brionne"
     },
     {
-        "id": 730,
+        "id": "730",
         "name": "Primarina"
     },
     {
-        "id": 731,
+        "id": "731",
         "name": "Pikipek"
     },
     {
-        "id": 732,
+        "id": "732",
         "name": "Trumbeak"
     },
     {
-        "id": 733,
+        "id": "733",
         "name": "Toucannon"
     },
     {
-        "id": 734,
+        "id": "734",
         "name": "Yungoos"
     },
     {
-        "id": 735,
+        "id": "735",
         "name": "Gumshoos"
     },
     {
-        "id": 736,
+        "id": "736",
         "name": "Grubbin"
     },
     {
-        "id": 737,
+        "id": "737",
         "name": "Charjabug"
     },
     {
-        "id": 738,
+        "id": "738",
         "name": "Vikavolt"
     },
     {
-        "id": 739,
+        "id": "739",
         "name": "Crabrawler"
     },
     {
-        "id": 740,
+        "id": "740",
         "name": "Crabominable"
     },
     {
-        "id": 741,
+        "id": "741",
         "name": "Oricorio"
     },
     {
-        "id": 742,
+        "id": "742",
         "name": "Cutiefly"
     },
     {
-        "id": 743,
+        "id": "743",
         "name": "Ribombee"
     },
     {
-        "id": 744,
+        "id": "744",
         "name": "Rockruff"
     },
     {
-        "id": 745,
+        "id": "745",
         "name": "Lycanroc"
     },
     {
-        "id": 746,
+        "id": "746",
         "name": "Wishiwashi"
     },
     {
-        "id": 747,
+        "id": "747",
         "name": "Mareanie"
     },
     {
-        "id": 748,
+        "id": "748",
         "name": "Toxapex"
     },
     {
-        "id": 749,
+        "id": "749",
         "name": "Mudbray"
     },
     {
-        "id": 750,
+        "id": "750",
         "name": "Mudsdale"
     },
     {
-        "id": 751,
+        "id": "751",
         "name": "Dewpider"
     },
     {
-        "id": 752,
+        "id": "752",
         "name": "Araquanid"
     },
     {
-        "id": 753,
+        "id": "753",
         "name": "Fomantis"
     },
     {
-        "id": 754,
+        "id": "754",
         "name": "Lurantis"
     },
     {
-        "id": 755,
+        "id": "755",
         "name": "Morelull"
     },
     {
-        "id": 756,
+        "id": "756",
         "name": "Shiinotic"
     },
     {
-        "id": 757,
+        "id": "757",
         "name": "Salandit"
     },
     {
-        "id": 758,
+        "id": "758",
         "name": "Salazzle"
     },
     {
-        "id": 759,
+        "id": "759",
         "name": "Stufful"
     },
     {
-        "id": 760,
+        "id": "760",
         "name": "Bewear"
     },
     {
-        "id": 761,
+        "id": "761",
         "name": "Bounsweet"
     },
     {
-        "id": 762,
+        "id": "762",
         "name": "Steenee"
     },
     {
-        "id": 763,
+        "id": "763",
         "name": "Tsareena"
     },
     {
-        "id": 764,
+        "id": "764",
         "name": "Comfey"
     },
     {
-        "id": 765,
+        "id": "765",
         "name": "Oranguru"
     },
     {
-        "id": 766,
+        "id": "766",
         "name": "Passimian"
     },
     {
-        "id": 767,
+        "id": "767",
         "name": "Wimpod"
     },
     {
-        "id": 768,
+        "id": "768",
         "name": "Golisopod"
     },
     {
-        "id": 769,
+        "id": "769",
         "name": "Sandygast"
     },
     {
-        "id": 770,
+        "id": "770",
         "name": "Palossand"
     },
     {
-        "id": 771,
+        "id": "771",
         "name": "Pyukumuku"
     },
     {
-        "id": 772,
+        "id": "772",
         "name": "Type: Null"
     },
     {
-        "id": 773,
+        "id": "773",
         "name": "Silvally"
     },
     {
-        "id": 774,
+        "id": "774",
         "name": "Minior"
     },
     {
-        "id": 775,
+        "id": "775",
         "name": "Komala"
     },
     {
-        "id": 776,
+        "id": "776",
         "name": "Turtonator"
     },
     {
-        "id": 777,
+        "id": "777",
         "name": "Togedemaru"
     },
     {
-        "id": 778,
+        "id": "778",
         "name": "Mimikyu"
     },
     {
-        "id": 779,
+        "id": "779",
         "name": "Bruxish"
     },
     {
-        "id": 780,
+        "id": "780",
         "name": "Drampa"
     },
     {
-        "id": 781,
+        "id": "781",
         "name": "Dhelmise"
     },
     {
-        "id": 782,
+        "id": "782",
         "name": "Jangmo-o"
     },
     {
-        "id": 783,
+        "id": "783",
         "name": "Hakamo-o"
     },
     {
-        "id": 784,
+        "id": "784",
         "name": "Kommo-o"
     },
     {
-        "id": 785,
+        "id": "785",
         "name": "Tapu Koko"
     },
     {
-        "id": 786,
+        "id": "786",
         "name": "Tapu Lele"
     },
     {
-        "id": 787,
+        "id": "787",
         "name": "Tapu Bulu"
     },
     {
-        "id": 788,
+        "id": "788",
         "name": "Tapu Fini"
     },
     {
-        "id": 789,
+        "id": "789",
         "name": "Cosmog"
     },
     {
-        "id": 790,
+        "id": "790",
         "name": "Cosmoem"
     },
     {
-        "id": 791,
+        "id": "791",
         "name": "Solgaleo"
     },
     {
-        "id": 792,
+        "id": "792",
         "name": "Lunala"
     },
     {
-        "id": 793,
+        "id": "793",
         "name": "Nihilego"
     },
     {
-        "id": 794,
+        "id": "794",
         "name": "Buzzwole"
     },
     {
-        "id": 795,
+        "id": "795",
         "name": "Pheromosa"
     },
     {
-        "id": 796,
+        "id": "796",
         "name": "Xurkitree"
     },
     {
-        "id": 797,
+        "id": "797",
         "name": "Celesteela"
     },
     {
-        "id": 798,
+        "id": "798",
         "name": "Kartana"
     },
     {
-        "id": 799,
+        "id": "799",
         "name": "Guzzlord"
     },
     {
-        "id": 800,
+        "id": "800",
         "name": "Necrozma"
     },
     {
-        "id": 801,
+        "id": "801",
         "name": "Magearna"
     },
     {
-        "id": 802,
+        "id": "802",
         "name": "Marshadow"
     },
     {
-        "id": 803,
+        "id": "803",
         "name": "Poipole"
     },
     {
-        "id": 804,
+        "id": "804",
         "name": "Naganadel"
     },
     {
-        "id": 805,
+        "id": "805",
         "name": "Stakataka"
     },
     {
-        "id": 806,
+        "id": "806",
         "name": "Blacephalon"
     },
     {
-        "id": 807,
+        "id": "807",
         "name": "Zeraora"
     },
     {
-        "id": 808,
+        "id": "808",
         "name": "Meltan"
     },
     {
-        "id": 809,
+        "id": "809",
         "name": "Melmetal"
     },
     {
-        "id": 810,
+        "id": "810",
         "name": "Grookey"
     },
     {
-        "id": 811,
+        "id": "811",
         "name": "Thwackey"
     },
     {
-        "id": 812,
+        "id": "812",
         "name": "Rillaboom"
     },
     {
-        "id": 813,
+        "id": "813",
         "name": "Scorbunny"
     },
     {
-        "id": 814,
+        "id": "814",
         "name": "Raboot"
     },
     {
-        "id": 815,
+        "id": "815",
         "name": "Cinderace"
     },
     {
-        "id": 816,
+        "id": "816",
         "name": "Sobble"
     },
     {
-        "id": 817,
+        "id": "817",
         "name": "Drizzile"
     },
     {
-        "id": 818,
+        "id": "818",
         "name": "Inteleon"
     },
     {
-        "id": 819,
+        "id": "819",
         "name": "Skwovet"
     },
     {
-        "id": 820,
+        "id": "820",
         "name": "Greedent"
     },
     {
-        "id": 821,
+        "id": "821",
         "name": "Rookidee"
     },
     {
-        "id": 822,
+        "id": "822",
         "name": "Corvisquire"
     },
     {
-        "id": 823,
+        "id": "823",
         "name": "Corviknight"
     },
     {
-        "id": 824,
+        "id": "824",
         "name": "Blipbug"
     },
     {
-        "id": 825,
+        "id": "825",
         "name": "Dottler"
     },
     {
-        "id": 826,
+        "id": "826",
         "name": "Orbeetle"
     },
     {
-        "id": 827,
+        "id": "827",
         "name": "Nickit"
     },
     {
-        "id": 828,
+        "id": "828",
         "name": "Thievul"
     },
     {
-        "id": 829,
+        "id": "829",
         "name": "Gossifleur"
     },
     {
-        "id": 830,
+        "id": "830",
         "name": "Eldegoss"
     },
     {
-        "id": 831,
+        "id": "831",
         "name": "Wooloo"
     },
     {
-        "id": 832,
+        "id": "832",
         "name": "Dubwool"
     },
     {
-        "id": 833,
+        "id": "833",
         "name": "Chewtle"
     },
     {
-        "id": 834,
+        "id": "834",
         "name": "Drednaw"
     },
     {
-        "id": 835,
+        "id": "835",
         "name": "Yamper"
     },
     {
-        "id": 836,
+        "id": "836",
         "name": "Boltund"
     },
     {
-        "id": 837,
+        "id": "837",
         "name": "Rolycoly"
     },
     {
-        "id": 838,
+        "id": "838",
         "name": "Carkol"
     },
     {
-        "id": 839,
+        "id": "839",
         "name": "Coalossal"
     },
     {
-        "id": 840,
+        "id": "840",
         "name": "Applin"
     },
     {
-        "id": 841,
+        "id": "841",
         "name": "Flapple"
     },
     {
-        "id": 842,
+        "id": "842",
         "name": "Appletun"
     },
     {
-        "id": 843,
+        "id": "843",
         "name": "Silicobra"
     },
     {
-        "id": 844,
+        "id": "844",
         "name": "Sandaconda"
     },
     {
-        "id": 845,
+        "id": "845",
         "name": "Cramorant"
     },
     {
-        "id": 846,
+        "id": "846",
         "name": "Arrokuda"
     },
     {
-        "id": 847,
+        "id": "847",
         "name": "Barraskewda"
     },
     {
-        "id": 848,
+        "id": "848",
         "name": "Toxel"
     },
     {
-        "id": 849,
+        "id": "849",
         "name": "Toxtricity"
     },
     {
-        "id": 850,
+        "id": "850",
         "name": "Sizzlipede"
     },
     {
-        "id": 851,
+        "id": "851",
         "name": "Centiskorch"
     },
     {
-        "id": 852,
+        "id": "852",
         "name": "Clobbopus"
     },
     {
-        "id": 853,
+        "id": "853",
         "name": "Grapploct"
     },
     {
-        "id": 854,
+        "id": "854",
         "name": "Sinistea"
     },
     {
-        "id": 855,
+        "id": "855",
         "name": "Polteageist"
     },
     {
-        "id": 856,
+        "id": "856",
         "name": "Hatenna"
     },
     {
-        "id": 857,
+        "id": "857",
         "name": "Hattrem"
     },
     {
-        "id": 858,
+        "id": "858",
         "name": "Hatterene"
     },
     {
-        "id": 859,
+        "id": "859",
         "name": "Impidimp"
     },
     {
-        "id": 860,
+        "id": "860",
         "name": "Morgrem"
     },
     {
-        "id": 861,
+        "id": "861",
         "name": "Grimmsnarl"
     },
     {
-        "id": 862,
+        "id": "862",
         "name": "Obstagoon"
     },
     {
-        "id": 863,
+        "id": "863",
         "name": "Perrserker"
     },
     {
-        "id": 864,
+        "id": "864",
         "name": "Cursola"
     },
     {
-        "id": 865,
+        "id": "865",
         "name": "Sirfetch'd"
     },
     {
-        "id": 866,
+        "id": "866",
         "name": "Mr. Rime"
     },
     {
-        "id": 867,
+        "id": "867",
         "name": "Runerigus"
     },
     {
-        "id": 868,
+        "id": "868",
         "name": "Milcery"
     },
     {
-        "id": 869,
+        "id": "869",
         "name": "Alcremie"
     },
     {
-        "id": 870,
+        "id": "870",
         "name": "Falinks"
     },
     {
-        "id": 871,
+        "id": "871",
         "name": "Pincurchin"
     },
     {
-        "id": 872,
+        "id": "872",
         "name": "Snom"
     },
     {
-        "id": 873,
+        "id": "873",
         "name": "Frosmoth"
     },
     {
-        "id": 874,
+        "id": "874",
         "name": "Stonjourner"
     },
     {
-        "id": 875,
+        "id": "875",
         "name": "Eiscue"
     },
     {
-        "id": 876,
+        "id": "876",
         "name": "Indeedee"
     },
     {
-        "id": 877,
+        "id": "877",
         "name": "Morpeko"
     },
     {
-        "id": 878,
+        "id": "878",
         "name": "Cufant"
     },
     {
-        "id": 879,
+        "id": "879",
         "name": "Copperajah"
     },
     {
-        "id": 880,
+        "id": "880",
         "name": "Dracozolt"
     },
     {
-        "id": 881,
+        "id": "881",
         "name": "Arctozolt"
     },
     {
-        "id": 882,
+        "id": "882",
         "name": "Dracovish"
     },
     {
-        "id": 883,
+        "id": "883",
         "name": "Arctovish"
     },
     {
-        "id": 884,
+        "id": "884",
         "name": "Duraludon"
     },
     {
-        "id": 885,
+        "id": "885",
         "name": "Dreepy"
     },
     {
-        "id": 886,
+        "id": "886",
         "name": "Drakloak"
     },
     {
-        "id": 887,
+        "id": "887",
         "name": "Dragapult"
     },
     {
-        "id": 888,
+        "id": "888",
         "name": "Zacian"
     },
     {
-        "id": 889,
+        "id": "889",
         "name": "Zamazenta"
     },
     {
-        "id": 890,
+        "id": "890",
         "name": "Eternatus"
     },
     {
-        "id": 891,
+        "id": "891",
         "name": "Kubfu"
     },
     {
-        "id": 892,
+        "id": "892",
         "name": "Urshifu"
     },
     {
-        "id": 893,
+        "id": "893",
         "name": "Zarude"
     },
     {
-        "id": 894,
+        "id": "894",
         "name": "Regieleki"
     },
     {
-        "id": 895,
+        "id": "895",
         "name": "Regidrago"
     },
     {
-        "id": 896,
+        "id": "896",
         "name": "Glastrier"
     },
     {
-        "id": 897,
+        "id": "897",
         "name": "Spectrier"
     },
     {
-        "id": 898,
+        "id": "898",
         "name": "Calyrex"
     },
     {
-        "id": 899,
+        "id": "899",
         "name": "Wyrdeer"
     },
     {
-        "id": 900,
+        "id": "900",
         "name": "Kleavor"
     },
     {
-        "id": 901,
+        "id": "901",
         "name": "Ursaluna"
     },
     {
-        "id": 902,
+        "id": "902",
         "name": "Basculegion"
     },
     {
-        "id": 903,
+        "id": "903",
         "name": "Sneasler"
     },
     {
-        "id": 904,
+        "id": "904",
         "name": "Overqwil"
     },
     {
-        "id": 905,
+        "id": "905",
         "name": "Enamorus"
     }
 ]

--- a/resources/js/components/pokedex-panel.tsx
+++ b/resources/js/components/pokedex-panel.tsx
@@ -19,14 +19,20 @@ export type PokedexEntry = {
     caught: boolean;
 };
 
+export type PokedexDefinition = {
+    slug: string;
+    name: string;
+    caught_count: number;
+    seen_count: number;
+    entries: PokedexEntry[];
+};
+
 type PokedexFilter = 'all' | 'caught' | 'seen';
 type EntryStatus = 'caught' | 'seen' | 'unseen';
 type IconComponent = ComponentType<SVGProps<SVGSVGElement> & { weight?: 'regular' | 'fill' }>;
 
 type PokedexPanelProps = {
-    pokedex: PokedexEntry[];
-    caughtCount: number;
-    seenCount: number;
+    pokedexes: PokedexDefinition[];
 };
 
 const filters: Array<{ key: PokedexFilter; label: string; icon: IconComponent }> = [
@@ -42,6 +48,10 @@ const statusIcons: Record<EntryStatus, IconComponent> = {
 };
 
 function formatDexNumber(id: string): string {
+    if (id.includes('_') || id.includes(';')) {
+        return `#${id}`;
+    }
+
     const numericId = Number.parseInt(id, 10);
 
     if (Number.isNaN(numericId)) {
@@ -87,11 +97,23 @@ function statusLabel(status: EntryStatus): string {
     return 'Unseen';
 }
 
-export function PokedexPanel({ pokedex, caughtCount, seenCount }: PokedexPanelProps) {
+function defaultDexSlug(pokedexes: PokedexDefinition[]): string {
+    const national = pokedexes.find((dex) => dex.slug === 'pokedex_national');
+
+    return national?.slug ?? pokedexes[0]?.slug ?? '';
+}
+
+export function PokedexPanel({ pokedexes }: PokedexPanelProps) {
+    const [activeDex, setActiveDex] = useState(() => defaultDexSlug(pokedexes));
     const [filter, setFilter] = useState<PokedexFilter>('all');
+
+    const selectedDex = pokedexes.find((dex) => dex.slug === activeDex) ?? pokedexes[0] ?? null;
+
+    const caughtCount = selectedDex?.caught_count ?? 0;
+    const seenCount = selectedDex?.seen_count ?? 0;
     const progress = seenCount > 0 ? Math.min(100, Math.round((caughtCount / seenCount) * 100)) : 0;
 
-    const filtered = pokedex.filter((entry) => {
+    const filtered = (selectedDex?.entries ?? []).filter((entry) => {
         if (filter === 'caught') {
             return entry.caught;
         }
@@ -103,8 +125,38 @@ export function PokedexPanel({ pokedex, caughtCount, seenCount }: PokedexPanelPr
         return true;
     });
 
+    if (pokedexes.length === 0) {
+        return (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <MagnifyingGlassIcon className="size-4" />
+                No Pokédex definitions available yet
+            </div>
+        );
+    }
+
     return (
         <div className="flex w-full min-w-0 flex-col gap-4">
+            <div className="flex flex-wrap gap-3 border-b border-border text-sm">
+                {pokedexes.map((dex) => (
+                    <button
+                        key={dex.slug}
+                        type="button"
+                        className={cn(
+                            'pb-2',
+                            (selectedDex?.slug ?? '') === dex.slug
+                                ? 'border-b-2 border-primary text-primary'
+                                : 'text-muted-foreground',
+                        )}
+                        onClick={() => {
+                            setActiveDex(dex.slug);
+                            setFilter('all');
+                        }}
+                    >
+                        {dex.name}
+                    </button>
+                ))}
+            </div>
+
             <div className="flex flex-col gap-3">
                 <div className="flex flex-wrap items-end justify-between gap-3">
                     <div className="flex flex-wrap gap-4 text-sm">

--- a/resources/js/pages/members/show.tsx
+++ b/resources/js/pages/members/show.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 import { DetailsPanel, type PlayerDetails } from '@/components/details-panel';
 import { PartyPanel, type PartyMember } from '@/components/party-panel';
-import { PokedexPanel, type PokedexEntry } from '@/components/pokedex-panel';
+import { PokedexPanel, type PokedexDefinition } from '@/components/pokedex-panel';
 import { StatisticsPanel, type StatisticItem } from '@/components/statistics-panel';
 import { TrophiesPanel, type TrophyItem } from '@/components/trophies-panel';
 import { Badge } from '@/components/ui/badge';
@@ -40,7 +40,7 @@ type Props = {
             seen_count?: number;
             party?: PartyMember[];
             details?: PlayerDetails;
-            pokedex?: PokedexEntry[];
+            pokedexes?: PokedexDefinition[];
             statistics?: StatisticItem[];
             trophies?: {
                 achieved: number;
@@ -222,11 +222,7 @@ export default function MembersShow({ member }: Props) {
                                     {saveTab === 'party' && <PartyPanel party={member.gameSave.party ?? []} />}
                                     {saveTab === 'details' && <DetailsPanel details={member.gameSave.details ?? {}} />}
                                     {saveTab === 'pokedex' && (
-                                        <PokedexPanel
-                                            pokedex={member.gameSave.pokedex ?? []}
-                                            caughtCount={member.gameSave.caught_count ?? 0}
-                                            seenCount={member.gameSave.seen_count ?? 0}
-                                        />
+                                        <PokedexPanel pokedexes={member.gameSave.pokedexes ?? []} />
                                     )}
                                     {saveTab === 'trophies' && (
                                         <TrophiesPanel

--- a/routes/console.php
+++ b/routes/console.php
@@ -7,6 +7,7 @@ use App\Console\Commands\NotifyGameUpdate;
 use App\Console\Commands\PingAllServers;
 use App\Console\Commands\SkinUserUpdate;
 use App\Console\Commands\SyncGameVersion;
+use App\Console\Commands\SyncPokedexFromGame;
 use Illuminate\Queue\Console\PruneBatchesCommand;
 use Illuminate\Queue\Console\PruneFailedJobsCommand;
 use Illuminate\Support\Facades\Schedule;
@@ -24,3 +25,4 @@ Schedule::command('disposable:update')->daily();
 // Weekly commands
 Schedule::command(PruneFailedJobsCommand::class)->weekly();
 Schedule::command(CleanUpActivity::class)->weekly();
+Schedule::command(SyncPokedexFromGame::class)->weekly();

--- a/tests/Feature/GameSavePokedexTest.php
+++ b/tests/Feature/GameSavePokedexTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Models\GamejoltAccount;
+use App\Models\GameSave;
+use App\Models\Pokedex;
+use App\Models\User;
+use App\Support\GameSavePresenter;
+
+test('game save resolves regional and unown form names', function () {
+    $gamesave = GameSave::factory()->create([
+        'pokedex' => "{19_alola|2}\r\n{201;0|1}",
+    ]);
+
+    expect($gamesave->getPokemonName('19_alola'))->toBe('Alolan Rattata')
+        ->and($gamesave->getPokemonName('201;0'))->toBe('Unown A')
+        ->and($gamesave->getPokemonName('9999_missing'))->toBe('???');
+});
+
+test('get pokedex by ids preserves definition order and fills missing entries', function () {
+    $gamesave = GameSave::factory()->create([
+        'pokedex' => "{4|1}\r\n{19_alola|2}",
+    ]);
+
+    $entries = $gamesave->getPokedexByIds(['19_alola', '1', '4']);
+
+    expect($entries)->toHaveCount(3)
+        ->and($entries[0])->toMatchArray([
+            'id' => '19_alola',
+            'name' => 'Alolan Rattata',
+            'seen' => true,
+            'caught' => true,
+        ])
+        ->and($entries[1])->toMatchArray([
+            'id' => '1',
+            'name' => 'Bulbasaur',
+            'seen' => false,
+            'caught' => false,
+        ])
+        ->and($entries[2])->toMatchArray([
+            'id' => '4',
+            'name' => 'Charmander',
+            'seen' => true,
+            'caught' => false,
+        ]);
+});
+
+test('game save presenter returns multi dex payload with per dex counts', function () {
+    $user = User::factory()->create();
+
+    GamejoltAccount::factory()->create([
+        'user_id' => $user->id,
+    ]);
+
+    GameSave::factory()->create([
+        'user_id' => $user->id,
+        'pokedex' => "{1|2}\r\n{19_alola|1}\r\n{25|2}",
+    ]);
+
+    Pokedex::factory()->create([
+        'name' => 'Kanto Pokédex',
+        'slug' => 'pokedex_kanto',
+        'pokemon_ids' => ['1', '25', '4'],
+    ]);
+
+    Pokedex::factory()->create([
+        'name' => 'Sevii Pokédex',
+        'slug' => 'pokedex_sevii',
+        'pokemon_ids' => ['19_alola', '26_alola'],
+    ]);
+
+    $payload = GameSavePresenter::forUser($user->fresh());
+
+    expect($payload['available'])->toBeTrue()
+        ->and($payload['caught_count'])->toBe(2)
+        ->and($payload['seen_count'])->toBe(3)
+        ->and($payload)->not->toHaveKey('pokedex')
+        ->and($payload['pokedexes'])->toHaveCount(2)
+        ->and($payload['pokedexes'][0])->toMatchArray([
+            'slug' => 'pokedex_kanto',
+            'name' => 'Kanto Pokédex',
+            'caught_count' => 2,
+            'seen_count' => 2,
+        ])
+        ->and($payload['pokedexes'][0]['entries'])->toHaveCount(3)
+        ->and($payload['pokedexes'][0]['entries'][0])->toMatchArray([
+            'id' => '1',
+            'name' => 'Bulbasaur',
+            'seen' => true,
+            'caught' => true,
+        ])
+        ->and($payload['pokedexes'][0]['entries'][2])->toMatchArray([
+            'id' => '4',
+            'name' => 'Charmander',
+            'seen' => false,
+            'caught' => false,
+        ])
+        ->and($payload['pokedexes'][1])->toMatchArray([
+            'slug' => 'pokedex_sevii',
+            'name' => 'Sevii Pokédex',
+            'caught_count' => 0,
+            'seen_count' => 1,
+        ])
+        ->and($payload['pokedexes'][1]['entries'][0])->toMatchArray([
+            'id' => '19_alola',
+            'name' => 'Alolan Rattata',
+            'seen' => true,
+            'caught' => false,
+        ]);
+});

--- a/tests/Feature/GameSavePresenterTest.php
+++ b/tests/Feature/GameSavePresenterTest.php
@@ -3,11 +3,12 @@
 use App\Models\GamejoltAccount;
 use App\Models\GamejoltAccountTrophy;
 use App\Models\GameSave;
+use App\Models\Pokedex;
 use App\Models\User;
 use App\Support\GameSavePresenter;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('game save presenter returns the full pokedex entry shape', function () {
+test('game save presenter returns the full pokedexes shape', function () {
     $user = User::factory()->create();
 
     GamejoltAccount::factory()->create([
@@ -19,31 +20,39 @@ test('game save presenter returns the full pokedex entry shape', function () {
         'pokedex' => "{1|2}\r\n{4|1}\r\n{7|0}\r\n{25|2}",
     ]);
 
+    Pokedex::factory()->create([
+        'name' => 'National Pokédex',
+        'slug' => 'pokedex_national',
+        'pokemon_ids' => ['1', '4', '7', '25'],
+    ]);
+
     $payload = GameSavePresenter::forUser($user->fresh());
 
     expect($payload['available'])->toBeTrue()
         ->and($payload['caught_count'])->toBe(2)
         ->and($payload['seen_count'])->toBe(3)
-        ->and($payload['pokedex'])->toHaveCount(4)
-        ->and($payload['pokedex'][0])->toMatchArray([
+        ->and($payload['pokedexes'])->toHaveCount(1)
+        ->and($payload['pokedexes'][0]['slug'])->toBe('pokedex_national')
+        ->and($payload['pokedexes'][0]['entries'])->toHaveCount(4)
+        ->and($payload['pokedexes'][0]['entries'][0])->toMatchArray([
             'id' => '1',
             'name' => 'Bulbasaur',
             'seen' => true,
             'caught' => true,
         ])
-        ->and($payload['pokedex'][1])->toMatchArray([
+        ->and($payload['pokedexes'][0]['entries'][1])->toMatchArray([
             'id' => '4',
             'name' => 'Charmander',
             'seen' => true,
             'caught' => false,
         ])
-        ->and($payload['pokedex'][2])->toMatchArray([
+        ->and($payload['pokedexes'][0]['entries'][2])->toMatchArray([
             'id' => '7',
             'name' => 'Squirtle',
             'seen' => false,
             'caught' => false,
         ])
-        ->and($payload['pokedex'][3])->toMatchArray([
+        ->and($payload['pokedexes'][0]['entries'][3])->toMatchArray([
             'id' => '25',
             'name' => 'Pikachu',
             'seen' => true,
@@ -51,7 +60,7 @@ test('game save presenter returns the full pokedex entry shape', function () {
         ]);
 });
 
-test('members show includes pokedex entries when a game save is available', function () {
+test('members show includes pokedexes when a game save is available', function () {
     $user = User::factory()->create([
         'username' => 'dextrainer',
     ]);
@@ -65,6 +74,12 @@ test('members show includes pokedex entries when a game save is available', func
         'pokedex' => "{1|2}\r\n{4|1}",
     ]);
 
+    Pokedex::factory()->create([
+        'name' => 'Kanto Pokédex',
+        'slug' => 'pokedex_kanto',
+        'pokemon_ids' => ['1', '4'],
+    ]);
+
     $this->get(route('member.show', $user->username))
         ->assertOk()
         ->assertInertia(fn (Assert $page) => $page
@@ -72,13 +87,16 @@ test('members show includes pokedex entries when a game save is available', func
             ->where('member.gameSave.available', true)
             ->where('member.gameSave.caught_count', 1)
             ->where('member.gameSave.seen_count', 2)
-            ->has('member.gameSave.pokedex', 2)
-            ->where('member.gameSave.pokedex.0.id', '1')
-            ->where('member.gameSave.pokedex.0.name', 'Bulbasaur')
-            ->where('member.gameSave.pokedex.0.seen', true)
-            ->where('member.gameSave.pokedex.0.caught', true)
-            ->where('member.gameSave.pokedex.1.id', '4')
-            ->where('member.gameSave.pokedex.1.caught', false));
+            ->has('member.gameSave.pokedexes', 1)
+            ->where('member.gameSave.pokedexes.0.slug', 'pokedex_kanto')
+            ->where('member.gameSave.pokedexes.0.caught_count', 1)
+            ->where('member.gameSave.pokedexes.0.seen_count', 2)
+            ->where('member.gameSave.pokedexes.0.entries.0.id', '1')
+            ->where('member.gameSave.pokedexes.0.entries.0.name', 'Bulbasaur')
+            ->where('member.gameSave.pokedexes.0.entries.0.seen', true)
+            ->where('member.gameSave.pokedexes.0.entries.0.caught', true)
+            ->where('member.gameSave.pokedexes.0.entries.1.id', '4')
+            ->where('member.gameSave.pokedexes.0.entries.1.caught', false));
 });
 
 test('game save presenter returns trophy details including difficulty and image', function () {

--- a/tests/Feature/SyncPokedexFromGameTest.php
+++ b/tests/Feature/SyncPokedexFromGameTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Console\Commands\SyncPokedexFromGame;
+use App\Models\Pokedex;
+use Illuminate\Support\Facades\Http;
+
+test('expand pokemon ids handles ranges regional forms unown and max', function () {
+    $command = new SyncPokedexFromGame;
+
+    expect($command->expandPokemonIds('1-3,19_alola,201;0,900-[MAX]'))->toBe([
+        '1',
+        '2',
+        '3',
+        '19_alola',
+        '201;0',
+        ...array_map('strval', range(900, SyncPokedexFromGame::NATIONAL_MAX)),
+    ]);
+});
+
+test('sync pokedex from game stores definitions from pokedex dat', function () {
+    Http::fake([
+        SyncPokedexFromGame::POKEDEX_DAT_URL => Http::response(
+            implode("\n", [
+                'Kanto Pokédex|pokedex_kanto|1-3,25|0',
+                'Sevii Pokédex|pokedex_sevii|19_alola,26_alola|0',
+                'Unown Pokédex|pokedex_unown|201;0,201;1|0',
+                'National Pokédex|pokedex_national|1-[MAX]|1',
+            ]),
+            200
+        ),
+    ]);
+
+    $this->artisan('sync:pokedexfromgame')
+        ->assertSuccessful();
+
+    expect(Pokedex::query()->count())->toBe(4);
+
+    $kanto = Pokedex::query()->where('slug', 'pokedex_kanto')->first();
+    expect($kanto)->not->toBeNull()
+        ->and($kanto->name)->toBe('Kanto Pokédex')
+        ->and($kanto->pokemon_ids)->toBe(['1', '2', '3', '25']);
+
+    $sevii = Pokedex::query()->where('slug', 'pokedex_sevii')->first();
+    expect($sevii->pokemon_ids)->toBe(['19_alola', '26_alola']);
+
+    $unown = Pokedex::query()->where('slug', 'pokedex_unown')->first();
+    expect($unown->pokemon_ids)->toBe(['201;0', '201;1']);
+
+    $national = Pokedex::query()->where('slug', 'pokedex_national')->first();
+    expect($national->pokemon_ids)->toHaveCount(SyncPokedexFromGame::NATIONAL_MAX)
+        ->and($national->pokemon_ids[0])->toBe('1')
+        ->and($national->pokemon_ids[SyncPokedexFromGame::NATIONAL_MAX - 1])->toBe((string) SyncPokedexFromGame::NATIONAL_MAX);
+});
+
+test('sync pokedex from game updates existing definitions by slug', function () {
+    Pokedex::factory()->create([
+        'slug' => 'pokedex_kanto',
+        'name' => 'Old Kanto',
+        'pokemon_ids' => ['1'],
+    ]);
+
+    Http::fake([
+        SyncPokedexFromGame::POKEDEX_DAT_URL => Http::response(
+            'Kanto Pokédex|pokedex_kanto|1-2|0',
+            200
+        ),
+    ]);
+
+    $this->artisan('sync:pokedexfromgame')
+        ->assertSuccessful();
+
+    expect(Pokedex::query()->count())->toBe(1)
+        ->and(Pokedex::query()->first()->name)->toBe('Kanto Pokédex')
+        ->and(Pokedex::query()->first()->pokemon_ids)->toBe(['1', '2']);
+});
+
+test('sync pokedex from game fails when the remote file cannot be fetched', function () {
+    Http::fake([
+        SyncPokedexFromGame::POKEDEX_DAT_URL => Http::response('Nope', 500),
+    ]);
+
+    $this->artisan('sync:pokedexfromgame')
+        ->assertFailed();
+
+    expect(Pokedex::query()->count())->toBe(0);
+});


### PR DESCRIPTION
- Closes #285
- Updated GameSave model to include a new method for retrieving Pokédex entries by IDs, returning unseen placeholders for missing entries.
- Enhanced getPokemonName method to improve error handling and data retrieval from language files.
- Modified GameSavePresenter to aggregate Pokédex data and updated related tests to reflect changes in data structure.
- Adjusted PokedexPanel component to accommodate new data format and ensure proper rendering of Pokédex definitions.
- Updated JSON language files to use string IDs for Pokémon, ensuring consistency across the application.